### PR TITLE
Minor Fixes

### DIFF
--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -1022,6 +1022,8 @@ namespace AvaloniaEdit.Editing
                 _viewPort = new Size(finalSize.Width, finalSize.Height / TextView.DefaultLineHeight);
                 _extent = new Size(finalSize.Width, LogicalScrollSize);
 
+                TextView.SetScrollData(new Size(_viewPort.Width, _viewPort.Height * TextView.DefaultLineHeight), _extent);
+
                 (this as ILogicalScrollable).InvalidateScroll?.Invoke();
             }
 

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -589,9 +589,9 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public Caret Caret { get; }
 
-        public void ScrollToLine(int line, double borderSizePc = 0.5)
+        public void ScrollToLine(int line, int linesEitherSide)
         {
-            var offset = line - (_viewPort.Height * borderSizePc);
+            var offset = line - linesEitherSide;
 
             if (offset < 0)
             {
@@ -600,7 +600,7 @@ namespace AvaloniaEdit.Editing
 
             this.BringIntoView(new Rect(1, offset, 0, 1));
 
-            offset = line + (_viewPort.Height * borderSizePc);
+            offset = line + linesEitherSide;
 
             if (offset >= 0)
             {
@@ -615,7 +615,7 @@ namespace AvaloniaEdit.Editing
 
             TextView.HighlightedLine = Caret.Line;
 
-            ScrollToLine(Caret.Line);
+            ScrollToLine(Caret.Line, 2);
 
             Dispatcher.UIThread.InvokeAsync(() =>
             {

--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -54,12 +54,12 @@ namespace AvaloniaEdit.Text
                 throw new NotSupportedException("Too many characters per line");
             }
 
-            while (run.IsEnd || run.Width <= widthLeft)
+            while (true)
             {
                 visibleLength += AddRunReturnVisibleLength(runs, run);
                 index += run.Length;
                 widthLeft -= run.Width;
-                if (run.IsEnd)
+                if (run.IsEnd || widthLeft <= 0)
                 {
                     trailing.SpaceWidth = 0;
                     UpdateTrailingInfo(runs, trailing);
@@ -68,8 +68,6 @@ namespace AvaloniaEdit.Text
 
                 run = TextLineRun.Create(textSource, index, firstIndex, widthLeft);
             }
-
-            return null;
         }
 
         private TextLineImpl(TextParagraphProperties paragraphProperties, int firstIndex, List<TextLineRun> runs, TrailingInfo trailing)

--- a/src/AvaloniaEdit/Utils/PixelSnapHelpers.cs
+++ b/src/AvaloniaEdit/Utils/PixelSnapHelpers.cs
@@ -24,7 +24,7 @@ namespace AvaloniaEdit.Utils
 	/// <summary>
 	/// Contains static helper methods for aligning stuff on a whole number of pixels.
 	/// </summary>
-	internal static class PixelSnapHelpers
+	public static class PixelSnapHelpers
 	{
 		/// <summary>
 		/// Gets the pixel size on the screen containing visual.


### PR DESCRIPTION
Generate visual lines sometimes was returning null and crashing, this cant happen anymore.
Arrange and measure now works correctly, fixes #23 
Mouse click scrolling and caret navigation now works as expected.
PixelSnap helpers are public for people creating their own background renderers.