### PR TITLE
Fix rendering of FoldingMarginMarkers

### DIFF
--- a/src/AvaloniaEdit/Folding/FoldingMargin.cs
+++ b/src/AvaloniaEdit/Folding/FoldingMargin.cs
@@ -157,7 +157,7 @@ namespace AvaloniaEdit.Folding
                 var xPos = (finalSize.Width - m.DesiredSize.Width) / 2;
                 m.Arrange(new Rect(PixelSnapHelpers.Round(new Point(xPos, yPos), pixelSize), m.DesiredSize));
             }
-            return base.ArrangeOverride(finalSize);
+            return finalSize;
         }
 
         private readonly List<FoldingMarginMarker> _markers = new List<FoldingMarginMarker>();
@@ -184,6 +184,7 @@ namespace AvaloniaEdit.Folding
                             VisualLine = line,
                             FoldingSection = fs
                         };
+                        ((ISetLogicalParent)m).SetParent(this);
 
                         _markers.Add(m);
                         VisualChildren.Add(m);


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/344204/44422112-93df0c00-a582-11e8-8e5a-1bc8593cadd6.png)

After:
![grafik](https://user-images.githubusercontent.com/344204/44422190-cb4db880-a582-11e8-97ae-df788ecff37e.png)

Notice the changes in the folding margin.