### PR TITLE
Fix inline objects

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml
@@ -6,8 +6,11 @@
     <DockPanel>
         <StackPanel Orientation="Horizontal"
                     DockPanel.Dock="Top"
+                    Spacing="5"
                     Margin="3">
             <Button Content="Copy" />
+            <Button Name="addControlBtn" Content="Add Button" />
+            <Button Name="clearControlBtn" Content="Clear Buttons" />
         </StackPanel>
         <AvalonEdit:TextEditor Name="Editor"
                                Margin="30"

--- a/src/AvaloniaEdit/Rendering/InlineObjectRun.cs
+++ b/src/AvaloniaEdit/Rendering/InlineObjectRun.cs
@@ -103,7 +103,7 @@ namespace AvaloniaEdit.Rendering
 
         public override Size GetSize(double remainingParagraphWidth)
         {
-            if (Element.IsArrangeValid)
+            if (Element.IsMeasureValid)
             {
                 return DesiredSize;
             }
@@ -113,10 +113,10 @@ namespace AvaloniaEdit.Rendering
 
         public override Rect ComputeBoundingBox()
         {
-            if (Element.IsArrangeValid)
+            if (Element.IsMeasureValid)
             {
                 var baseline = DesiredSize.Height;
-                return new Rect(new Point(0, -baseline), DesiredSize);
+                return new Rect(DesiredSize);
             }
 
             return Rect.Empty;

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -445,6 +445,7 @@ namespace AvaloniaEdit.Rendering
             if (!alreadyAdded)
             {
                 VisualChildren.Add(inlineObject.Element);
+                ((ISetLogicalParent)inlineObject.Element).SetParent(this);
             }
             inlineObject.Element.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
             inlineObject.DesiredSize = inlineObject.Element.DesiredSize;

--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -99,7 +99,7 @@ namespace AvaloniaEdit.Text
                 WidthIncludingTrailingWhitespace += run.Width;
             }
 
-            Height = height.IsClose(Baseline + top) ? height : Baseline;
+            Height = Math.Max(height, Baseline + top);
 
             if (Height <= 0)
             {

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -28,9 +28,39 @@ namespace AvaloniaEdit.Text
 
         public bool IsEmbedded { get; private set; }
 
-        public double Baseline => IsEnd ? 0.0 : FontSize * BaselineFactor;
+        public double Baseline
+        {
+            get
+            {
+                if (IsEnd)
+                {
+                    return 0.0;
+                }
+                if (IsEmbedded && TextRun is TextEmbeddedObject embeddedObject)
+                {
+                    var box = embeddedObject.ComputeBoundingBox();
+                    return box.Y;
+                }
+                return FontSize * BaselineFactor;
+            }
+        }
 
-        public double Height => IsEnd ? 0.0 : FontSize * HeightFactor;
+        public double Height
+        {
+            get
+            {
+                if(IsEnd)
+                {
+                    return 0.0;
+                }
+                if(IsEmbedded && TextRun is TextEmbeddedObject embeddedObject)
+                {
+                    var box = embeddedObject.ComputeBoundingBox();
+                    return box.Height;
+                }
+                return FontSize * HeightFactor;
+            }
+        }
 
         public Typeface Typeface => TextRun.Properties.Typeface;
 


### PR DESCRIPTION
Fixes:

- Inline object does not show up
- The line with Inline objects may collapse 

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1737680/46265227-5eaacf80-c4d9-11e8-9600-2d7e1c0c872c.png">

Known issues:
- Cannot scroll down if the height of the inline object is large ( because TextView's scroll size depends on the number of lines)