### PR TITLE
Fix editor shortcuts on mac replacing ctrl with cmd

### DIFF
--- a/src/AvaloniaEdit/AvaloniaEditCommands.cs
+++ b/src/AvaloniaEdit/AvaloniaEditCommands.cs
@@ -17,7 +17,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 using Avalonia.Input;
+using Avalonia.Platform;
 
 namespace AvaloniaEdit
 {
@@ -99,15 +101,46 @@ namespace AvaloniaEdit
 
     public static class ApplicationCommands
     {
+        private static readonly KeyModifiers PlatformCommandKey = GetPlatformCommandKey();
+        
         public static RoutedCommand Delete { get; } = new RoutedCommand(nameof(Delete), new KeyGesture { Key = Key.Delete });
-        public static RoutedCommand Copy { get; } = new RoutedCommand(nameof(Copy), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.C });
-        public static RoutedCommand Cut { get; } = new RoutedCommand(nameof(Cut), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.X });
-        public static RoutedCommand Paste { get; } = new RoutedCommand(nameof(Paste), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.V });
-        public static RoutedCommand SelectAll { get; } = new RoutedCommand(nameof(SelectAll));
-        public static RoutedCommand Undo { get; } = new RoutedCommand(nameof(Undo), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.Z });
-        public static RoutedCommand Redo { get; } = new RoutedCommand(nameof(Redo), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.Y });
-        public static RoutedCommand Find { get; } = new RoutedCommand(nameof(Find), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.F });
-        public static RoutedCommand Replace { get; } = new RoutedCommand(nameof(Replace), new KeyGesture { KeyModifiers = KeyModifiers.Control, Key = Key.H });
+        public static RoutedCommand Copy { get; } = new RoutedCommand(nameof(Copy), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.C });
+        public static RoutedCommand Cut { get; } = new RoutedCommand(nameof(Cut), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.X });
+        public static RoutedCommand Paste { get; } = new RoutedCommand(nameof(Paste), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.V });
+        public static RoutedCommand SelectAll { get; } = new RoutedCommand(nameof(SelectAll), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.A });
+        public static RoutedCommand Undo { get; } = new RoutedCommand(nameof(Undo), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.Z });
+        public static RoutedCommand Redo { get; } = new RoutedCommand(nameof(Redo), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.Y });
+        public static RoutedCommand Find { get; } = new RoutedCommand(nameof(Find), new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.F });
+        public static RoutedCommand Replace { get; } = new RoutedCommand(nameof(Replace), GetReplaceKeyGesture());
+
+        private static OperatingSystemType GetOperatingSystemType()
+        {
+            return AvaloniaLocator.Current.GetService<IRuntimePlatform>().GetRuntimeInfo().OperatingSystem;
+        }
+        
+        private static KeyModifiers GetPlatformCommandKey()
+        {
+            var os = GetOperatingSystemType();
+            
+            if (os == OperatingSystemType.OSX)
+            {
+                return KeyModifiers.Meta;
+            }
+
+            return KeyModifiers.Control;
+        }
+
+        private static KeyGesture GetReplaceKeyGesture()
+        {
+            var os = GetOperatingSystemType();
+
+            if (os == OperatingSystemType.OSX)
+            {
+                return new KeyGesture { KeyModifiers = KeyModifiers.Meta | KeyModifiers.Alt, Key = Key.F };
+            }
+
+            return new KeyGesture { KeyModifiers = PlatformCommandKey, Key = Key.H };
+        }
     }
 
     public static class EditingCommands

--- a/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
@@ -62,9 +62,14 @@ namespace AvaloniaEdit.Editing
         static readonly List<RoutedCommandBinding> CommandBindings = new List<RoutedCommandBinding>();
         static readonly List<KeyBinding> KeyBindings = new List<KeyBinding>();
 
-        private static void AddBinding(RoutedCommand command, KeyModifiers modifiers, Key key, EventHandler<ExecutedRoutedEventArgs> handler)
+        private static void AddBinding(RoutedCommand command, EventHandler<ExecutedRoutedEventArgs> handler)
         {
             CommandBindings.Add(new RoutedCommandBinding(command, handler));
+        }
+
+        private static void AddBinding(RoutedCommand command, KeyModifiers modifiers, Key key, EventHandler<ExecutedRoutedEventArgs> handler)
+        {
+            AddBinding(command, handler);
             KeyBindings.Add(TextAreaDefaultInputHandler.CreateKeyBinding(command, modifiers, key));
         }
 
@@ -108,7 +113,7 @@ namespace AvaloniaEdit.Editing
             AddBinding(EditingCommands.MoveToDocumentEnd, KeyModifiers.Control, Key.End, OnMoveCaret(CaretMovementType.DocumentEnd));
             AddBinding(EditingCommands.SelectToDocumentEnd, KeyModifiers.Control | KeyModifiers.Shift, Key.End, OnMoveCaretExtendSelection(CaretMovementType.DocumentEnd));
 
-            AddBinding(ApplicationCommands.SelectAll, KeyModifiers.Control, Key.A, OnSelectAll);
+            AddBinding(ApplicationCommands.SelectAll, OnSelectAll);
         }
 
         private static void OnSelectAll(object target, ExecutedRoutedEventArgs args)


### PR DESCRIPTION
* Replace shortcut for mac is set to CMD + ALT + F because CMD + H is used for "hide window" system command

Fixes: #78 