### PR TITLE
Fix line number font size 

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Platform;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -53,6 +54,13 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.TextView.ElementGenerators.Add(_generator);
 
             impl = PlatformManager.CreateWindow().CreatePopup();
+
+            this.AddHandler(PointerWheelChangedEvent, (o, i) =>
+            {
+                if (i.KeyModifiers != KeyModifiers.Control) return;
+                if (i.Delta.Y > 0) _textEditor.FontSize++;
+                else _textEditor.FontSize--;
+            }, RoutingStrategies.Bubble, true);
         }
 
         private void InitializeComponent()

--- a/src/AvaloniaEdit/Editing/LineNumberMargin.cs
+++ b/src/AvaloniaEdit/Editing/LineNumberMargin.cs
@@ -68,6 +68,8 @@ namespace AvaloniaEdit.Editing
         /// <inheritdoc/>
         public override void Render(DrawingContext drawingContext)
         {
+            EmSize = GetValue(TextBlock.FontSizeProperty);
+
             var textView = TextView;
             var renderSize = Bounds.Size;
             if (textView != null && textView.VisualLinesValid)
@@ -82,8 +84,7 @@ namespace AvaloniaEdit.Editing
                         Typeface, EmSize, foreground
                     );
                     var y = line.GetTextLineVisualYPosition(line.TextLines[0], VisualYPosition.TextTop);
-                    drawingContext.DrawText(foreground, new Point(renderSize.Width - text.Bounds.Width, y - textView.VerticalOffset),
-                        text);
+                    drawingContext.DrawText(foreground, new Point(renderSize.Width - text.Bounds.Width, y - textView.VerticalOffset), text);
                 }
             }
         }


### PR DESCRIPTION
## Current behavior
If the fontsize is changed while the editor is visible the line numbers will not change their size
![Unbenannt](https://user-images.githubusercontent.com/25281882/67639023-43341300-f8eb-11e9-8672-6d2be6968010.PNG)

## Expected behavior
![Unbenannt](https://user-images.githubusercontent.com/25281882/67639040-6c54a380-f8eb-11e9-8dba-55d6b1e033c4.PNG)

## How?
Just update the size before rendering using `EmSize = GetValue(TextBlock.FontSizeProperty);`
Maybe we should call the method `MeasureOverride(Size availableSize)` instead since it updates the fontsize aswell but I am not sure.

I added the ability to change the FontSize with CTRL+Scroll in the Demo.