### PR TITLE
WIP: Fix compiling issues to run on latest version of Avalonia

### DIFF
--- a/src/AvaloniaEdit.Demo/AvaloniaEdit.Demo.csproj
+++ b/src/AvaloniaEdit.Demo/AvaloniaEdit.Demo.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.999-cibuild0006181-beta" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.9.999-cibuild0006181-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AvaloniaEdit/AvaloniaEdit.csproj
+++ b/src/AvaloniaEdit/AvaloniaEdit.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="0.9.999-cibuild0006181-beta" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -59,7 +59,7 @@ namespace AvaloniaEdit.CodeCompletion
         /// </summary>
         public ControlTemplate EmptyTemplate
         {
-            get => GetValue(EmptyTemplateProperty);
+            get => GetValue(EmptyTemplateProperty) as ControlTemplate;
             set => SetValue(EmptyTemplateProperty, value);
         }
 

--- a/src/AvaloniaEdit/CodeCompletion/OverloadViewer.cs
+++ b/src/AvaloniaEdit/CodeCompletion/OverloadViewer.cs
@@ -42,7 +42,7 @@ namespace AvaloniaEdit.CodeCompletion
         /// </summary>
         public string Text
         {
-            get => GetValue(TextProperty);
+            get => GetValue(TextProperty) as string;
             set => SetValue(TextProperty, value);
         }
 
@@ -82,7 +82,7 @@ namespace AvaloniaEdit.CodeCompletion
         /// </summary>
         public IOverloadProvider Provider
         {
-            get => GetValue(ProviderProperty);
+            get => GetValue(ProviderProperty) as IOverloadProvider;
             set => SetValue(ProviderProperty, value);
         }
 

--- a/src/AvaloniaEdit/Editing/AbstractMargin.cs
+++ b/src/AvaloniaEdit/Editing/AbstractMargin.cs
@@ -55,7 +55,7 @@ namespace AvaloniaEdit.Editing
         /// <remarks>Adding a margin to <see cref="TextArea.LeftMargins"/> will automatically set this property to the text area's TextView.</remarks>
         public TextView TextView
         {
-            get => GetValue(TextViewProperty);
+            get => GetValue(TextViewProperty) as TextView;
             set => SetValue(TextViewProperty, value);
         }
 

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -20,6 +20,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -242,7 +243,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public TextDocument Document
         {
-            get => GetValue(DocumentProperty);
+            get => GetValue(DocumentProperty) as TextDocument;
             set => SetValue(DocumentProperty, value);
         }
 
@@ -294,7 +295,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public TextEditorOptions Options
         {
-            get => GetValue(OptionsProperty);
+            get => GetValue(OptionsProperty) as TextEditorOptions;
             set => SetValue(OptionsProperty, value);
         }
 
@@ -485,7 +486,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public IBrush SelectionBrush
         {
-            get => GetValue(SelectionBrushProperty);
+            get => GetValue(SelectionBrushProperty) as IBrush;
             set => SetValue(SelectionBrushProperty, value);
         }
 
@@ -500,7 +501,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public IBrush SelectionForeground
         {
-            get => GetValue(SelectionForegroundProperty);
+            get => GetValue(SelectionForegroundProperty) as IBrush;
             set => SetValue(SelectionForegroundProperty, value);
         }
 
@@ -515,7 +516,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public Pen SelectionBorder
         {
-            get => GetValue(SelectionBorderProperty);
+            get => GetValue(SelectionBorderProperty) as Pen;
             set => SetValue(SelectionBorderProperty, value);
         }
 
@@ -530,7 +531,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public double SelectionCornerRadius
         {
-            get => GetValue(SelectionCornerRadiusProperty);
+            get => (double)GetValue(SelectionCornerRadiusProperty);
             set => SetValue(SelectionCornerRadiusProperty, value);
         }
         #endregion
@@ -904,7 +905,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public IIndentationStrategy IndentationStrategy
         {
-            get => GetValue(IndentationStrategyProperty);
+            get => GetValue(IndentationStrategyProperty) as IIndentationStrategy;
             set => SetValue(IndentationStrategyProperty, value);
         }
         #endregion
@@ -992,24 +993,24 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public bool OverstrikeMode
         {
-            get => GetValue(OverstrikeModeProperty);
+            get => (bool)GetValue(OverstrikeModeProperty);
             set => SetValue(OverstrikeModeProperty, value);
         }
 
         #endregion
 
         /// <inheritdoc/>
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        protected override void OnPropertyChanged<T>(AvaloniaProperty<T> property, Optional<T> oldValue, BindingValue<T> newValue, BindingPriority priority)
         {
-            base.OnPropertyChanged(e);
-            if (e.Property == SelectionBrushProperty
-                || e.Property == SelectionBorderProperty
-                || e.Property == SelectionForegroundProperty
-                || e.Property == SelectionCornerRadiusProperty)
+            base.OnPropertyChanged(property, oldValue, newValue, priority);
+            if (property == SelectionBrushProperty
+                || property == SelectionBorderProperty
+                || property == SelectionForegroundProperty
+                || property == SelectionCornerRadiusProperty)
             {
                 TextView.Redraw();
             }
-            else if (e.Property == OverstrikeModeProperty)
+            else if (property == OverstrikeModeProperty)
             {
                 Caret.UpdateIfVisible();
             }

--- a/src/AvaloniaEdit/Folding/FoldingMarginMarker.cs
+++ b/src/AvaloniaEdit/Folding/FoldingMarginMarker.cs
@@ -22,6 +22,7 @@ using AvaloniaEdit.Utils;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Data;
 
 namespace AvaloniaEdit.Folding
 {
@@ -107,10 +108,11 @@ namespace AvaloniaEdit.Folding
             }
         }
 
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        /// <inheritdoc/>
+        protected override void OnPropertyChanged<T>(AvaloniaProperty<T> property, Optional<T> oldValue, BindingValue<T> newValue, BindingPriority priority)
         {
-            base.OnPropertyChanged(e);
-            if (e.Property == IsPointerOverProperty)
+            base.OnPropertyChanged(property, oldValue, newValue, priority);
+            if (property == IsPointerOverProperty)
             {
                 InvalidateVisual();
             }

--- a/src/AvaloniaEdit/Highlighting/HighlightingColorizer.cs
+++ b/src/AvaloniaEdit/Highlighting/HighlightingColorizer.cs
@@ -273,9 +273,8 @@ namespace AvaloniaEdit.Highlighting
                 var tf = element.TextRunProperties.Typeface;
                 element.TextRunProperties.Typeface = new Avalonia.Media.Typeface(
                     tf.FontFamily,
-                    tf.FontSize,
-                    color.FontStyle ?? tf.Style,
-                    color.FontWeight ?? tf.Weight
+                    color.FontWeight ?? tf.Weight,
+                    color.FontStyle ?? tf.Style
                 );
             }
             //if(color.Underline ?? false)

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -547,7 +548,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public IBrush NonPrintableCharacterBrush
         {
-            get => GetValue(NonPrintableCharacterBrushProperty);
+            get => GetValue(NonPrintableCharacterBrushProperty) as IBrush;
             set => SetValue(NonPrintableCharacterBrushProperty, value);
         }
 
@@ -562,7 +563,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public IBrush LinkTextForegroundBrush
         {
-            get => GetValue(LinkTextForegroundBrushProperty);
+            get => GetValue(LinkTextForegroundBrushProperty) as IBrush;
             set => SetValue(LinkTextForegroundBrushProperty, value);
         }
 
@@ -577,7 +578,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public IBrush LinkTextBackgroundBrush
         {
-            get => GetValue(LinkTextBackgroundBrushProperty);
+            get => GetValue(LinkTextBackgroundBrushProperty) as IBrush;
             set => SetValue(LinkTextBackgroundBrushProperty, value);
         }
         #endregion
@@ -597,7 +598,7 @@ namespace AvaloniaEdit.Rendering
         /// </remarks>
         public bool LinkTextUnderline
         {
-            get => GetValue(LinkTextUnderlineProperty);
+            get => (bool)GetValue(LinkTextUnderlineProperty);
             set => SetValue(LinkTextUnderlineProperty, value);
         }
 
@@ -1056,7 +1057,7 @@ namespace AvaloniaEdit.Rendering
             var properties = new TextRunProperties
             {
                 FontSize = FontSize,
-                Typeface = new Typeface(TextBlock.GetFontFamily(this), FontSize, TextBlock.GetFontStyle(this), TextBlock.GetFontWeight(this)),
+                Typeface = new Typeface(TextBlock.GetFontFamily(this), TextBlock.GetFontWeight(this), TextBlock.GetFontStyle(this)),
                 ForegroundBrush = TextBlock.GetForeground(this),
                 CultureInfo = CultureInfo.CurrentCulture
             };
@@ -1920,24 +1921,24 @@ namespace AvaloniaEdit.Rendering
         }
 
         /// <inheritdoc/>
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        protected override void OnPropertyChanged<T>(AvaloniaProperty<T> property, Optional<T> oldValue, BindingValue<T> newValue, BindingPriority priority)
         {
-            base.OnPropertyChanged(e);
+            base.OnPropertyChanged(property, oldValue, newValue, priority);
 
-            if (e.Property == TemplatedControl.ForegroundProperty
-                     || e.Property == NonPrintableCharacterBrushProperty
-                     || e.Property == LinkTextBackgroundBrushProperty
-                     || e.Property == LinkTextForegroundBrushProperty
-                     || e.Property == LinkTextUnderlineProperty)
+            if (property == TemplatedControl.ForegroundProperty
+                     || property == NonPrintableCharacterBrushProperty
+                     || property == LinkTextBackgroundBrushProperty
+                     || property == LinkTextForegroundBrushProperty
+                     || property == LinkTextUnderlineProperty)
             {
                 // changing brushes requires recreating the cached elements
                 RecreateCachedElements();
                 Redraw();
             }
-            if (e.Property == TemplatedControl.FontFamilyProperty
-                || e.Property == TemplatedControl.FontSizeProperty
-                || e.Property == TemplatedControl.FontStyleProperty
-                || e.Property == TemplatedControl.FontWeightProperty)
+            if (property == TemplatedControl.FontFamilyProperty
+                || property == TemplatedControl.FontSizeProperty
+                || property == TemplatedControl.FontStyleProperty
+                || property == TemplatedControl.FontWeightProperty)
             {
                 // changing font properties requires recreating cached elements
                 RecreateCachedElements();
@@ -1945,15 +1946,15 @@ namespace AvaloniaEdit.Rendering
                 InvalidateDefaultTextMetrics();
                 Redraw();
             }
-            if (e.Property == ColumnRulerPenProperty)
+            if (property == ColumnRulerPenProperty)
             {
                 _columnRulerRenderer.SetRuler(Options.ColumnRulerPosition, ColumnRulerPen);
             }
-            if (e.Property == CurrentLineBorderProperty)
+            if (property == CurrentLineBorderProperty)
             {
                 _currentLineHighlighRenderer.BorderPen = CurrentLineBorder;
             }
-            if (e.Property == CurrentLineBackgroundProperty)
+            if (property == CurrentLineBackgroundProperty)
             {
                 _currentLineHighlighRenderer.BackgroundBrush = CurrentLineBackground;
             }
@@ -2000,7 +2001,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public Pen ColumnRulerPen
         {
-            get => GetValue(ColumnRulerPenProperty);
+            get => GetValue(ColumnRulerPenProperty) as Pen;
             set => SetValue(ColumnRulerPenProperty, value);
         }
 
@@ -2015,7 +2016,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public IBrush CurrentLineBackground
         {
-            get => GetValue(CurrentLineBackgroundProperty);
+            get => GetValue(CurrentLineBackgroundProperty) as IBrush;
             set => SetValue(CurrentLineBackgroundProperty, value);
         }
 
@@ -2030,7 +2031,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public Pen CurrentLineBorder
         {
-            get => GetValue(CurrentLineBorderProperty);
+            get => GetValue(CurrentLineBorderProperty) as Pen;
             set => SetValue(CurrentLineBorderProperty, value);
         }
 

--- a/src/AvaloniaEdit/Search/DropDownButton.cs
+++ b/src/AvaloniaEdit/Search/DropDownButton.cs
@@ -40,7 +40,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public Popup DropDownContent
         {
-            get => GetValue(DropDownContentProperty);
+            get => GetValue(DropDownContentProperty) as Popup;
             set => SetValue(DropDownContentProperty, value);
         }
 
@@ -55,7 +55,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public bool IsDropDownContentOpen
         {
-            get => GetValue(IsDropDownContentOpenProperty);
+            get => (bool)GetValue(IsDropDownContentOpenProperty);
             protected set => SetValue(IsDropDownContentOpenProperty, value);
         }
 

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -57,7 +57,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public bool UseRegex
         {
-            get => GetValue(UseRegexProperty);
+            get => (bool)GetValue(UseRegexProperty);
             set => SetValue(UseRegexProperty, value);
         }
 
@@ -72,7 +72,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public bool MatchCase
         {
-            get => GetValue(MatchCaseProperty);
+            get => (bool)GetValue(MatchCaseProperty);
             set => SetValue(MatchCaseProperty, value);
         }
 
@@ -87,7 +87,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public bool WholeWords
         {
-            get => GetValue(WholeWordsProperty);
+            get => (bool)GetValue(WholeWordsProperty);
             set => SetValue(WholeWordsProperty, value);
         }
 
@@ -102,12 +102,12 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public string SearchPattern
         {
-            get => GetValue(SearchPatternProperty);
+            get => GetValue(SearchPatternProperty) as string;
             set => SetValue(SearchPatternProperty, value);
         }
 
         public static readonly AvaloniaProperty<bool> IsReplaceModeProperty =
-            AvaloniaProperty.Register<SearchPanel, bool>(nameof(IsReplaceMode), validate: ValidateReplaceMode);
+            AvaloniaProperty.Register<SearchPanel, bool>(nameof(IsReplaceMode));
 
         /// <summary>
         /// Checks if replacemode is allowed
@@ -121,7 +121,7 @@ namespace AvaloniaEdit.Search
 
         public bool IsReplaceMode
         {
-            get => GetValue(IsReplaceModeProperty);
+            get => (bool)GetValue(IsReplaceModeProperty);
             set => SetValue(IsReplaceModeProperty, _textEditor?.IsReadOnly ?? false ? false : value);
         }
 
@@ -130,7 +130,7 @@ namespace AvaloniaEdit.Search
 
         public string ReplacePattern
         {
-            get => GetValue(ReplacePatternProperty);
+            get => GetValue(ReplacePatternProperty) as string;
             set => SetValue(ReplacePatternProperty, value);
         }
 
@@ -146,7 +146,7 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public IBrush MarkerBrush
         {
-            get => GetValue(MarkerBrushProperty);
+            get => GetValue(MarkerBrushProperty) as IBrush;
             set => SetValue(MarkerBrushProperty, value);
         }
 

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -166,7 +166,8 @@ namespace AvaloniaEdit.Text
             var formattedText = new FormattedText
             {
                 Text = stringRange.ToString(),
-                Typeface = new Typeface(tf.FontFamily, run.FontSize, tf.Style, tf.Weight),
+                Typeface = new Typeface(tf.FontFamily, tf.Weight, tf.Style),
+                FontSize = run.FontSize
             };
        
 
@@ -199,7 +200,8 @@ namespace AvaloniaEdit.Text
                 var size = new FormattedText
                 {
                     Text = StringRange[i].ToString(),
-                    Typeface = new Typeface(tf.FontFamily, FontSize, tf.Style, tf.Weight)
+                    Typeface = new Typeface(tf.FontFamily, tf.Weight, tf.Style),
+                    FontSize = FontSize
                 }.Bounds.Size;
                 
                 result[i] = size.Width;

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -109,7 +109,7 @@ namespace AvaloniaEdit
         /// </summary>
         public TextDocument Document
         {
-            get => GetValue(DocumentProperty);
+            get => GetValue(DocumentProperty) as TextDocument;
             set => SetValue(DocumentProperty, value);
         }
 
@@ -162,7 +162,7 @@ namespace AvaloniaEdit
         /// </summary>
         public TextEditorOptions Options
         {
-            get => GetValue(OptionsProperty);
+            get => GetValue(OptionsProperty) as TextEditorOptions;
             set => SetValue(OptionsProperty, value);
         }
 
@@ -299,7 +299,7 @@ namespace AvaloniaEdit
         /// </summary>
         public IHighlightingDefinition SyntaxHighlighting
         {
-            get => GetValue(SyntaxHighlightingProperty);
+            get => GetValue(SyntaxHighlightingProperty) as IHighlightingDefinition;
             set => SetValue(SyntaxHighlightingProperty, value);
         }
 
@@ -357,7 +357,7 @@ namespace AvaloniaEdit
         /// </remarks>
         public bool WordWrap
         {
-            get => GetValue(WordWrapProperty);
+            get => (bool)GetValue(WordWrapProperty);
             set => SetValue(WordWrapProperty, value);
         }
         #endregion
@@ -376,7 +376,7 @@ namespace AvaloniaEdit
         /// </summary>
         public bool IsReadOnly
         {
-            get => GetValue(IsReadOnlyProperty);
+            get => (bool)GetValue(IsReadOnlyProperty);
             set => SetValue(IsReadOnlyProperty, value);
         }
 
@@ -404,7 +404,7 @@ namespace AvaloniaEdit
         /// </summary>
         public bool IsModified
         {
-            get => GetValue(IsModifiedProperty);
+            get => (bool)GetValue(IsModifiedProperty);
             set => SetValue(IsModifiedProperty, value);
         }
 
@@ -452,7 +452,7 @@ namespace AvaloniaEdit
         /// </summary>
         public bool ShowLineNumbers
         {
-            get => GetValue(ShowLineNumbersProperty);
+            get => (bool)GetValue(ShowLineNumbersProperty);
             set => SetValue(ShowLineNumbersProperty, value);
         }
 
@@ -502,7 +502,7 @@ namespace AvaloniaEdit
         /// </summary>
         public IBrush LineNumbersForeground
         {
-            get => GetValue(LineNumbersForegroundProperty);
+            get => GetValue(LineNumbersForegroundProperty) as IBrush;
             set => SetValue(LineNumbersForegroundProperty, value);
         }
 
@@ -962,7 +962,7 @@ namespace AvaloniaEdit
         /// </remarks>
         public Encoding Encoding
         {
-            get => GetValue(EncodingProperty);
+            get => GetValue(EncodingProperty) as Encoding;
             set => SetValue(EncodingProperty, value);
         }
 

--- a/src/AvaloniaEdit/Utils/TextFormatterFactory.cs
+++ b/src/AvaloniaEdit/Utils/TextFormatterFactory.cs
@@ -59,7 +59,8 @@ namespace AvaloniaEdit.Utils
             var formattedText = new FormattedText
             {
                 Text = text,
-                Typeface = new Typeface(typeface, emSize.Value)
+                Typeface = new Typeface(typeface),
+				FontSize = emSize.Value
             };
 	        
 	        formattedText.SetTextStyle(0, text.Length, foreground);


### PR DESCRIPTION
I did some work to get `AvaloniaEdit` compiling on the latest Avalonia. There was an issue that I wasn't sure what to do about:

1. `SearchPanel.IsReplaceModeProperty` validation function removed (signature has changed)

This PR should be considered WIP/not done/do not merge until the above issue is fixed. Plus, it's based on an unstable version of Avalonia, so it shouldn't be merged into `master` anyway. This is done merely to save the maintainers some time in their own work if possible.