### PR TITLE
Re-enable ScrollToEnd and ScrollToHome in TextEditor

### DIFF
--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -686,8 +686,7 @@ namespace AvaloniaEdit
         public void ScrollToEnd()
         {
             ApplyTemplate(); // ensure scrollViewer is created
-            //if (scrollViewer != null)
-            //    scrollViewer.ScrollToEnd();
+            ScrollViewer?.ScrollToEnd();
         }
 
         /// <summary>
@@ -696,8 +695,7 @@ namespace AvaloniaEdit
         public void ScrollToHome()
         {
             ApplyTemplate(); // ensure scrollViewer is created
-            //if (scrollViewer != null)
-            //    scrollViewer.ScrollToHome();
+            ScrollViewer?.ScrollToHome();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR simply re-enables `ScrollToEnd()` and `ScrollToHome()` in `TextEditor`. Those methods exist on `ScrollViewer` (although I think they didn't at some point), so I can't think of a reason why they shouldn't be allowed again. 😄 