### PR TITLE
Port of font family & font size highlighting support from AvalonEdit

### DIFF
--- a/src/AvaloniaEdit/Highlighting/HighlightingColor.cs
+++ b/src/AvaloniaEdit/Highlighting/HighlightingColor.cs
@@ -21,6 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Avalonia.Media;
+using AvaloniaEdit.Rendering;
 using AvaloniaEdit.Utils;
 
 namespace AvaloniaEdit.Highlighting
@@ -33,6 +34,8 @@ namespace AvaloniaEdit.Highlighting
         internal static readonly HighlightingColor Empty = FreezableHelper.FreezeAndReturn(new HighlightingColor());
 
         private string _name;
+        private FontFamily _fontFamily;
+        private int? _fontSize;
         private FontWeight? _fontWeight;
         private FontStyle? _fontStyle;
         private bool? _underline;
@@ -50,6 +53,40 @@ namespace AvaloniaEdit.Highlighting
                 if (IsFrozen)
                     throw new InvalidOperationException();
                 _name = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets the font family. Null if the highlighting color does not change the font style.
+        /// </summary>
+        public FontFamily FontFamily
+        {
+            get
+            {
+                return _fontFamily;
+            }
+            set
+            {
+                if (IsFrozen)
+                    throw new InvalidOperationException();
+                _fontFamily = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets the font size. Null if the highlighting color does not change the font style.
+        /// </summary>
+        public int? FontSize
+        {
+            get
+            {
+                return _fontSize;
+            }
+            set
+            {
+                if (IsFrozen)
+                    throw new InvalidOperationException();
+                _fontSize = value;
             }
         }
 
@@ -156,6 +193,18 @@ namespace AvaloniaEdit.Highlighting
             {
                 b.AppendFormat(CultureInfo.InvariantCulture, "color: #{0:x2}{1:x2}{2:x2}; ", c.Value.R, c.Value.G, c.Value.B);
             }
+            if (FontFamily != null)
+            {
+                b.Append("font-family: ");
+                b.Append(FontFamily.Name.ToLowerInvariant());
+                b.Append("; ");
+            }
+            if (FontSize != null)
+            {
+                b.Append("font-size: ");
+                b.Append(FontSize.Value.ToString());
+                b.Append("; ");
+            }
             if (FontWeight != null)
             {
                 b.Append("font-weight: ");
@@ -225,7 +274,8 @@ namespace AvaloniaEdit.Highlighting
                 return false;
             return _name == other._name && _fontWeight == other._fontWeight
                 && _fontStyle == other._fontStyle && _underline == other._underline
-                && Equals(_foreground, other._foreground) && Equals(_background, other._background);
+                && Equals(_foreground, other._foreground) && Equals(_background, other._background)
+                && Equals(_fontFamily, other._fontFamily) && Equals(_fontSize, other._fontSize);
         }
 
         /// <inheritdoc/>
@@ -243,6 +293,10 @@ namespace AvaloniaEdit.Highlighting
                     hashCode += 1000000033 * _foreground.GetHashCode();
                 if (_background != null)
                     hashCode += 1000000087 * _background.GetHashCode();
+                if (_fontFamily != null)
+                    hashCode += 1000000123 * _fontFamily.GetHashCode();
+                if (_fontSize != null)
+                    hashCode += 1000000167 * _fontSize.GetHashCode();
             }
             return hashCode;
         }
@@ -254,6 +308,10 @@ namespace AvaloniaEdit.Highlighting
         public void MergeWith(HighlightingColor color)
         {
             FreezableHelper.ThrowIfFrozen(this);
+            if (color._fontFamily != null)
+                _fontFamily = color._fontFamily;
+            if (color._fontSize != null)
+                _fontSize = color._fontSize;
             if (color._fontWeight != null)
                 _fontWeight = color._fontWeight;
             if (color._fontStyle != null)
@@ -267,6 +325,7 @@ namespace AvaloniaEdit.Highlighting
         }
 
         internal bool IsEmptyForMerge => _fontWeight == null && _fontStyle == null && _underline == null
-                                         && _foreground == null && _background == null;
+                                         && _foreground == null && _background == null
+                                         && _fontFamily == null && _fontSize == null;
     }
 }

--- a/src/AvaloniaEdit/Highlighting/HighlightingColorizer.cs
+++ b/src/AvaloniaEdit/Highlighting/HighlightingColorizer.cs
@@ -268,15 +268,17 @@ namespace AvaloniaEdit.Highlighting
                 if (b != null)
                     element.BackgroundBrush = b;
             }
-            if (color.FontStyle != null || color.FontWeight != null)
+            if (color.FontStyle != null || color.FontWeight != null || color.FontFamily != null)
             {
                 var tf = element.TextRunProperties.Typeface;
                 element.TextRunProperties.Typeface = new Avalonia.Media.Typeface(
-                    tf.FontFamily,                    
+                    color.FontFamily ?? tf.FontFamily,                    
                     color.FontStyle ?? tf.Style,
                     color.FontWeight ?? tf.Weight
                 );
             }
+            if (color.FontSize.HasValue)
+                element.TextRunProperties.FontSize = color.FontSize.Value;
             //if(color.Underline ?? false)
             //	element.TextRunProperties.SetTextDecorations(TextDecorations.Underline);
         }

--- a/src/AvaloniaEdit/Highlighting/Resources/MarkDownWithFontSize-Mode.xshd
+++ b/src/AvaloniaEdit/Highlighting/Resources/MarkDownWithFontSize-Mode.xshd
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0"?>
+<SyntaxDefinition name="MarkDownWithFontSize" extensions=".md" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+  <Color name="Heading1" foreground="Maroon" fontSize="30" exampleText="# Title #" />
+  <Color name="Heading2" foreground="Maroon" fontSize="27" exampleText="# Title #" />
+  <Color name="Heading3" foreground="Maroon" fontSize="24" exampleText="# Title #" />
+  <Color name="Heading4" foreground="Maroon" fontSize="21" exampleText="# Title #" />
+  <Color name="Heading5" foreground="Maroon" fontSize="18" exampleText="# Title #" />
+  <Color name="Heading6" foreground="Maroon" fontSize="15" exampleText="# Title #" />
+  <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
+  <Color name="StrongEmphasis" fontWeight="bold" exampleText="**this** is more important!" />
+  <Color name="Code" fontFamily="Footlight MT Light" exampleText="this is `int.GetHashCode()`" />
+  <Color name="BlockQuote" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
+  <Color name="Link" foreground="Blue" exampleText="[text](http://example.com)" />
+  <Color name="Image" foreground="Green" exampleText="[text][http://example.com/test.png]" />
+  <Color name="LineBreak" background="LightGray" exampleText="end of line      \r\n2nd line   " />
+
+  <RuleSet ignoreCase="true">
+    <Rule color="Heading1">
+      ^[#]{1}[ ]{1}.*
+    </Rule>
+    <Rule color="Heading2">
+      ^[#]{2}[ ]{1}.*
+    </Rule>
+    <Rule color="Heading3">
+      ^[#]{3}[ ]{1}.*
+    </Rule>
+    <Rule color="Heading4">
+      ^[#]{4}[ ]{1}.*
+    </Rule>
+    <Rule color="Heading5">
+      ^[#]{5}[ ]{1}.*
+    </Rule>
+    <Rule color="Heading6">
+      ^[#]{6}[ ]{1}.*
+    </Rule>
+    <Rule color="StrongEmphasis">
+      \*\*.*\*\*
+    </Rule>
+    <Rule color="StrongEmphasis">
+      __.*__
+    </Rule>
+    <Rule color="Emphasis">
+      \*(?![ ]).*\*
+    </Rule>
+    <Rule color="Emphasis">
+      _.*_
+    </Rule>
+    <Rule color="Code">
+      `.*`
+    </Rule>
+    <Span color="Code" ruleSet="C#/" multiline="true">
+      <Begin>^\t</Begin>
+      <End>^(?!\t)</End>
+    </Span>
+    <Span color="Code" ruleSet="C#/" multiline="true">
+      <Begin>^[ ]{4}</Begin>
+      <End>^(?![ ]{4})</End>
+    </Span>
+    <Span color="BlockQuote" multiline="true">
+      <Begin>^&gt;</Begin>
+      <End>^(?!&gt;)</End>
+    </Span>
+    <Rule color="Image">
+      \!\[.*\]\[.*\]
+    </Rule>
+    <Rule color="Link">
+      \[.*\]\(.*\)
+    </Rule>
+    <Rule color="Link">
+      \[.*\]\[.*\]
+    </Rule>
+    <Rule color="LineBreak">
+      [ ]{2}$
+    </Rule>
+  </RuleSet>
+</SyntaxDefinition>

--- a/src/AvaloniaEdit/Highlighting/Resources/ModeV2.xsd
+++ b/src/AvaloniaEdit/Highlighting/Resources/ModeV2.xsd
@@ -35,6 +35,8 @@
 		<xsd:attribute name="background" type="xsd:string" use="optional" />
 		<xsd:attribute name="fontWeight" type="FontWeight" use="optional" />
 		<xsd:attribute name="fontStyle" type="FontStyle" use="optional" />
+    <xsd:attribute name="fontFamily" type="xsd:string" use="optional" />
+    <xsd:attribute name="fontSize" type="xsd:integer" use="optional" />
 		<xsd:attribute name="underline" type="xsd:boolean" use="optional" />
 		<xsd:anyAttribute namespace="##other" processContents="lax" />
 	</xsd:attributeGroup>

--- a/src/AvaloniaEdit/Highlighting/Resources/Resources.cs
+++ b/src/AvaloniaEdit/Highlighting/Resources/Resources.cs
@@ -60,6 +60,7 @@ namespace AvaloniaEdit.Highlighting
 			                         "XML-Mode.xshd");
             hlm.RegisterHighlighting("XAML", new[] { ".xaml", ".paml", ".axaml" }, "XML-Mode.xshd");
 			hlm.RegisterHighlighting("MarkDown", new[] { ".md" }, "MarkDown-Mode.xshd");
+			hlm.RegisterHighlighting("MarkDownWithFontSize", new[] { ".md" }, "MarkDownWithFontSize-Mode.xshd");
 		}
 	}
 }

--- a/src/AvaloniaEdit/Highlighting/Xshd/V2Loader.cs
+++ b/src/AvaloniaEdit/Highlighting/Xshd/V2Loader.cs
@@ -320,6 +320,8 @@ namespace AvaloniaEdit.Highlighting.Xshd
             color.FontWeight = ParseFontWeight(reader.GetAttribute("fontWeight"));
             color.FontStyle = ParseFontStyle(reader.GetAttribute("fontStyle"));
             color.Underline = reader.GetBoolAttribute("underline");
+            color.FontFamily = ParseFontFamily(reader.GetAttribute("fontFamily"));
+            color.FontSize = ParseFontSize(reader.GetAttribute("fontSize"));
             return color;
         }        
 
@@ -335,6 +337,18 @@ namespace AvaloniaEdit.Highlighting.Xshd
             if (color == null)
                 return null;
             return new SimpleHighlightingBrush(color.Value);
+        }
+
+        private static FontFamily ParseFontFamily(string fontFamily)
+        {
+            if (string.IsNullOrEmpty(fontFamily))
+                return null;
+            return new FontFamily(fontFamily);
+        }
+
+        private static int? ParseFontSize(string size)
+        {
+            return int.TryParse(size, out int result) ? result : (int?)null;
         }
 
         private static FontWeight? ParseFontWeight(string fontWeight)

--- a/src/AvaloniaEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
+++ b/src/AvaloniaEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
@@ -209,6 +209,8 @@ namespace AvaloniaEdit.Highlighting.Xshd
                 c.Underline = color.Underline;
                 c.FontStyle = color.FontStyle;
                 c.FontWeight = color.FontWeight;
+                c.FontFamily = color.FontFamily;
+                c.FontSize = color.FontSize;
                 return c;
             }
 

--- a/src/AvaloniaEdit/Highlighting/Xshd/XshdColor.cs
+++ b/src/AvaloniaEdit/Highlighting/Xshd/XshdColor.cs
@@ -39,7 +39,17 @@ namespace AvaloniaEdit.Highlighting.Xshd
 		/// Gets/sets the background brush.
 		/// </summary>
 		public HighlightingBrush Background { get; set; }
-		
+
+		/// <summary>
+		/// Gets/sets the font family
+		/// </summary>
+		public FontFamily FontFamily { get; set; }
+
+		/// <summary>
+		/// Gets/sets the font size.
+		/// </summary>
+		public int? FontSize { get; set; }
+
 		/// <summary>
 		/// Gets/sets the font weight.
 		/// </summary>


### PR DESCRIPTION
Ported from https://github.com/icsharpcode/AvalonEdit/commit/a49d3fdbcfc02487da8a7dc6207ab35c775a859a.