### PR TITLE
Customize for LineNumbers separator

### DIFF
--- a/src/AvaloniaEdit/AvaloniaEdit.csproj
+++ b/src/AvaloniaEdit/AvaloniaEdit.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+    <PackageReference Include="Avalonia" Version="0.10.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/AvaloniaEdit/Editing/DottedLineMargin.cs
+++ b/src/AvaloniaEdit/Editing/DottedLineMargin.cs
@@ -42,7 +42,6 @@ namespace AvaloniaEdit.Editing
             {
                 StartPoint = new Point(0, 0),
                 EndPoint = new Point(0, 1),
-                StrokeDashArray = new AvaloniaList<double> { 0, 2 },
                 Stretch = Stretch.Fill,
                 StrokeThickness = 1,
                 StrokeLineCap = PenLineCap.Round,

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Avalonia;
+using Avalonia.Collections;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Editing;
 using AvaloniaEdit.Highlighting;
@@ -35,6 +36,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Data;
 using AvaloniaEdit.Search;
+using JetBrains.Annotations;
 
 namespace AvaloniaEdit
 {
@@ -470,7 +472,11 @@ namespace AvaloniaEdit
                 leftMargins.Insert(0, lineNumbers);
                 leftMargins.Insert(1, line);
                 var lineNumbersForeground = new Binding("LineNumbersForeground") { Source = editor };
+                var lineNumbersStroke = new Binding("LineNumbersStroke") { Source = editor };
+                var lineNumbersStrokeDashArray = new Binding("LineNumbersStrokeDashArray") { Source = editor };
                 line.Bind(Shape.StrokeProperty, lineNumbersForeground);
+                line.Bind(Shape.StrokeProperty, lineNumbersStroke);
+                line.Bind(Shape.StrokeDashArrayProperty, lineNumbersStrokeDashArray);
                 lineNumbers.Bind(ForegroundProperty, lineNumbersForeground);
             }
             else
@@ -506,7 +512,7 @@ namespace AvaloniaEdit
             get => GetValue(LineNumbersForegroundProperty);
             set => SetValue(LineNumbersForegroundProperty, value);
         }
-
+        
         private static void OnLineNumbersForegroundChanged(AvaloniaPropertyChangedEventArgs e)
         {
             var editor = e.Sender as TextEditor;
@@ -516,6 +522,41 @@ namespace AvaloniaEdit
         }
         #endregion
 
+        #region LineNumbersStroke
+        /// <summary>
+        /// LineNumbersStroke dependency property.
+        /// </summary>
+        public static readonly StyledProperty<IBrush> LineNumbersStrokeProperty =
+            AvaloniaProperty.Register<TextEditor, IBrush>("LineNumbersStroke", Brushes.Gray);
+        
+        /// <summary>
+        /// Gets/sets the Brush used for displaying the stroke color of line numbers.
+        /// </summary>
+        public IBrush LineNumbersStroke
+        {
+            get => GetValue(LineNumbersStrokeProperty);
+            set => SetValue(LineNumbersStrokeProperty, value);
+        }
+        #endregion
+        
+        #region LineNumbersStrokeDashArray   
+        /// <summary>
+        /// LineNumbersStrokeDashArray dependency property.
+        /// </summary>
+        public static readonly StyledProperty<AvaloniaList<double>> LineNumbersStrokeDashArrayProperty =
+            AvaloniaProperty.Register<TextEditor, AvaloniaList<double>>("LineNumbersStrokeDashArray", new AvaloniaList<double> { 0, 2 });
+        
+        /// <summary>
+        /// Gets or sets a collection of <see cref="double"/> values that indicate the pattern of dashes and gaps that is used to line numbers separator.
+        /// </summary>
+        [CanBeNull]
+        public AvaloniaList<double> LineNumbersStrokeDashArray
+        {
+            get => GetValue(LineNumbersStrokeDashArrayProperty);
+            set => SetValue(LineNumbersStrokeDashArrayProperty, value);
+        }
+        #endregion
+        
         #region TextBoxBase-like methods
         /// <summary>
         /// Appends text to the end of the document.

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -471,12 +471,11 @@ namespace AvaloniaEdit
                 var line = (Line)DottedLineMargin.Create();
                 leftMargins.Insert(0, lineNumbers);
                 leftMargins.Insert(1, line);
-                var lineNumbersForeground = new Binding("LineNumbersForeground") { Source = editor };
                 var lineNumbersStroke = new Binding("LineNumbersStroke") { Source = editor };
                 var lineNumbersStrokeDashArray = new Binding("LineNumbersStrokeDashArray") { Source = editor };
-                line.Bind(Shape.StrokeProperty, lineNumbersForeground);
                 line.Bind(Shape.StrokeProperty, lineNumbersStroke);
                 line.Bind(Shape.StrokeDashArrayProperty, lineNumbersStrokeDashArray);
+                var lineNumbersForeground = new Binding("LineNumbersForeground") { Source = editor };
                 lineNumbers.Bind(ForegroundProperty, lineNumbersForeground);
             }
             else


### PR DESCRIPTION
Add two new properties for Customization  LineNumbers separator:

- LineNumbersStrokeProperty
- LineNumbersStrokeDashArray

_Now StrokeDashArray is not nullable because nullables are disabled in the project, and their activation leads to many errors and requires a change in part of the logic._

To define a solid line, you can set:

```C#
LineNumbersStrokeDashArray = "0, 0"

```

