### PR TITLE
Change typecheck from SolidColorBrush to ISolidColorBrush

### DIFF
--- a/src/AvaloniaEdit/Editing/CaretLayer.cs
+++ b/src/AvaloniaEdit/Editing/CaretLayer.cs
@@ -97,7 +97,7 @@ namespace AvaloniaEdit.Editing
 
                 if (_textArea.OverstrikeMode)
                 {
-                    if (caretBrush is SolidColorBrush scBrush)
+                    if (caretBrush is ISolidColorBrush scBrush)
                     {
                         var brushColor = scBrush.Color;
                         var newColor = Color.FromArgb(100, brushColor.R, brushColor.G, brushColor.B);

--- a/src/AvaloniaEdit/Highlighting/HighlightingBrush.cs
+++ b/src/AvaloniaEdit/Highlighting/HighlightingBrush.cs
@@ -39,7 +39,7 @@ namespace AvaloniaEdit.Highlighting
 		/// <param name="context">The construction context. context can be null!</param>
 		public virtual Color? GetColor(ITextRunConstructionContext context)
 		{
-		    if (GetBrush(context) is SolidColorBrush scb)
+		    if (GetBrush(context) is ISolidColorBrush scb)
                 return scb.Color;
 		    return null;
 		}


### PR DESCRIPTION
`HighlightingBrush.GetColor` often returns null even though static colors is used.

The reason is that `HighlightingBrush.GetBrush` may return `ImmutableSolidColorBrush` and` GetColor` only checks `SolidColorBrush`.

This PR enable `GetColor` to use ImmutableSolidColorBrush, which inherits ISolidColorBrush.