### PR TITLE
Fixed NullReferenceException in ScrollToLine

### DIFF
--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -613,11 +613,18 @@ namespace AvaloniaEdit.Editing
         /// <param name="line">The line to scroll to.</param>
         public void ScrollToLine (int line)
         {
-            var viewPortLines = (int)(this as IScrollable).Viewport.Height;
-
-            if (viewPortLines < Document.LineCount)
+            try
             {
-                ScrollToLine(line, 2, viewPortLines / 2);
+                var viewPortLines = (int)(this as IScrollable).Viewport.Height;
+
+                if (viewPortLines < Document.LineCount)
+                {
+                    ScrollToLine(line, 2, viewPortLines / 2);
+                }
+            }
+            catch (Exception exec)
+            {
+                Console.WriteLine($"Error scrolling to line {line}: {exec}");
             }
         }
 


### PR DESCRIPTION
This bug seemed to cause an error on my system when I attempted to open a file with an unhandled NullReferenceException, so it has been resolved with try/catch until the root cause of this can be investigated.

![image](https://user-images.githubusercontent.com/73035340/119243339-a0428a00-bb5d-11eb-829d-26a74241baa5.png)
