### PR TITLE
Avoid corrupting VisibleVisualLines when calling GetOrConstructVisualLine

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -719,7 +719,7 @@ namespace AvaloniaEdit.Rendering
                 }
                 _allVisualLines.Clear();
 
-                _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_allVisualLines);
+                _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_allVisualLines.ToArray());
             }
         }
 
@@ -932,7 +932,7 @@ namespace AvaloniaEdit.Rendering
             {
                 // no document -> create empty list of lines
                 _allVisualLines = new List<VisualLine>();
-                _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_allVisualLines);
+                _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_allVisualLines.ToArray());
                 maxWidth = 0;
             }
             else
@@ -1036,7 +1036,7 @@ namespace AvaloniaEdit.Rendering
 
             _allVisualLines = _newVisualLines;
             // visibleVisualLines = readonly copy of visual lines
-            _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_newVisualLines);
+            _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_newVisualLines.ToArray());
             _newVisualLines = null;
 
             if (_allVisualLines.Any(line => line.IsDisposed))


### PR DESCRIPTION
When calling GetOrConstructVisualLine, the new line is added to the `_allVisualLines` collection. This causes the `_visibleVisualLines` collection to change. Imagine the following example

_visibleVisualLines has the following lines:

```
line5
line6
line7
line8
line9
```

Now suppose you build and `GetOrConstructVisualLine` line 2. The visual `_visibleVisualLines` collection ends having the following contents:

```
line5
line6
line7
line8
line9
line2
```

Taking a look at the original [avalonedit's TextView](https://github.com/icsharpcode/AvalonEdit/blob/master/ICSharpCode.AvalonEdit/Rendering/TextView.cs), when creating the `ReadonlyCollection `for the `_visibleVisualLines` it doesn't wrap a collection over the `_allVisualLines`.

It uses `.ToArray()` to make the `_visibleVisualLines `to be a new collection. Applied the same technique here.