### PR TITLE
Fix #99, cursor position for last line displays below last line

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -1211,7 +1211,8 @@ namespace AvaloniaEdit.Rendering
             }
 
             // Apply final view port and offset
-            SetScrollData(finalSize, _documentSize, new Vector(newScrollOffsetX, newScrollOffsetY));
+            if (SetScrollData(finalSize, _documentSize, new Vector(newScrollOffsetX, newScrollOffsetY)))
+                InvalidateMeasure(DispatcherPriority.Normal);
 
             if (_visibleVisualLines != null)
             {


### PR DESCRIPTION
This fixes bug when caret position was sometimes displayed in wrong place, while document lines where slightly off position.

This change matches with original AvalonEdit: https://github.com/icsharpcode/AvalonEdit/blob/master/ICSharpCode.AvalonEdit/Rendering/TextView.cs#L1186