### PR TITLE
Fix AvaloniaEdit when collapsing external controls

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -970,6 +970,10 @@ namespace AvaloniaEdit.Rendering
 
             TextLayer.SetVisualLines(_visibleVisualLines);
 
+            SetScrollData(availableSize,
+                          new Size(maxWidth, heightTreeHeight),
+                          _scrollOffset);
+
             // Size of control (scorll viewport) might be changed during ArrageOverride. We only need document size for now.
             _documentSize = new Size(maxWidth, heightTreeHeight);
 


### PR DESCRIPTION
Code ported from WPF upstream.
closes #142 