### PR TITLE
Fix background color in template

### DIFF
--- a/src/AvaloniaEdit/TextEditor.xaml
+++ b/src/AvaloniaEdit/TextEditor.xaml
@@ -4,7 +4,8 @@
     <Style Selector="AvalonEdit|TextEditor">
         <Setter Property="Template">
             <ControlTemplate>
-                <Border BorderBrush="{TemplateBinding BorderBrush}"
+                <Border Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}">
                     <ScrollViewer Focusable="False"
                                   Name="PART_ScrollViewer"


### PR DESCRIPTION
In the TextEditor control template, background wasn't set, therefore you couldn't set control background using Background property.

This change matches original AvalonEdit: https://github.com/icsharpcode/AvalonEdit/blob/master/ICSharpCode.AvalonEdit/TextEditor.xaml#L14