### PR TITLE
Fix scroll after resize with 125% DPI

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -1215,7 +1215,7 @@ namespace AvaloniaEdit.Rendering
             }
 
             // Apply final view port and offset
-            if (SetScrollData(finalSize, _documentSize, new Vector(newScrollOffsetX, newScrollOffsetY)))
+            if (SetScrollData(_scrollViewport, _scrollExtent, new Vector(newScrollOffsetX, newScrollOffsetY)))
                 InvalidateMeasure(DispatcherPriority.Normal);
 
             if (_visibleVisualLines != null)


### PR DESCRIPTION
Our code doesn't match upstream https://github.com/icsharpcode/AvalonEdit/blob/master/ICSharpCode.AvalonEdit/Rendering/TextView.cs#L1185
Also fixes that problem on 175% DPI
closes #147 