### PR TITLE
Fixed search results appearing under the search panel

### DIFF
--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -44,6 +44,7 @@ namespace AvaloniaEdit.Search
         private SearchResultBackgroundRenderer _renderer;
         private TextBox _searchTextBox;
         private TextEditor _textEditor { get; set; }
+        private Border _border;
 
         #region DependencyProperties
         /// <summary>
@@ -294,6 +295,7 @@ namespace AvaloniaEdit.Search
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
+            _border = e.NameScope.Find<Border>("PART_Border");
             _searchTextBox = e.NameScope.Find<TextBox>("PART_searchTextBox");
             _messageView = e.NameScope.Find<Popup>("PART_MessageView");
             _messageViewContent = e.NameScope.Find<ContentPresenter>("PART_MessageContent");
@@ -435,7 +437,7 @@ namespace AvaloniaEdit.Search
         {
             _textArea.Caret.Offset = result.StartOffset;
             _textArea.Selection = Selection.Create(_textArea, result.StartOffset, result.EndOffset);
-            _textArea.Caret.BringCaretToView();
+            _textArea.Caret.BringCaretToView(_border.Bounds.Height + _textArea.TextView.DefaultLineHeight);
             // show caret even if the editor does not have the Keyboard Focus
             _textArea.Caret.Show();
         }

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -437,7 +437,12 @@ namespace AvaloniaEdit.Search
         {
             _textArea.Caret.Offset = result.StartOffset;
             _textArea.Selection = Selection.Create(_textArea, result.StartOffset, result.EndOffset);
-            _textArea.Caret.BringCaretToView(_border.Bounds.Height + _textArea.TextView.DefaultLineHeight);
+
+            double distanceToViewBorder = _border == null ?
+                Caret.MinimumDistanceToViewBorder :
+                _border.Bounds.Height + _textArea.TextView.DefaultLineHeight;
+            _textArea.Caret.BringCaretToView(distanceToViewBorder);
+
             // show caret even if the editor does not have the Keyboard Focus
             _textArea.Caret.Show();
         }

--- a/src/AvaloniaEdit/Search/SearchPanel.xaml
+++ b/src/AvaloniaEdit/Search/SearchPanel.xaml
@@ -40,7 +40,7 @@
         <Setter Property="Focusable" Value="True" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border BorderThickness="{TemplateBinding BorderThickness}"
+                <Border Name="PART_Border" BorderThickness="{TemplateBinding BorderThickness}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 Background="{TemplateBinding Background}"
                 HorizontalAlignment="Right"


### PR DESCRIPTION
Closes #155.

When calling BringCaretToView, take into account the height of the search panel and give that margin (plus an extra line height) to ensure that the search result is visible.

