### PR TITLE
Fixed the caret position when multiline editing

### DIFF
--- a/src/AvaloniaEdit/Editing/RectangleSelection.cs
+++ b/src/AvaloniaEdit/Editing/RectangleSelection.cs
@@ -318,7 +318,7 @@ namespace AvaloniaEdit.Editing
                     pos = new TextViewPosition(_document.GetLocation(editOffset + firstInsertionLength));
                     TextArea.ClearSelection();
                 }
-                TextArea.Caret.Position = TextArea.TextView.GetPosition(new Point(GetXPos(TextArea, pos), TextArea.TextView.GetVisualTopByDocumentLine(Math.Max(_startLine, _endLine)))).GetValueOrDefault();
+                TextArea.Caret.Position = new TextViewPosition(Math.Max(_startLine, _endLine), pos.Column);
             }
         }
 


### PR DESCRIPTION
This PR fixes the following scenario:

1. Paste the content of this [sample-file.txt](https://github.com/AvaloniaUI/AvaloniaEdit/files/7560976/sample-file.txt) in the AvaloniaEdit window.
2. Go to line 25, column 12 (the beginning of the line).
3. Pres <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd> 4 times to make a multiline selection to line 29.
4. Type something.

Actual results: The caret goes to line 1.
Expected results: The caret maintains in line 29.