### PR TITLE
Fixed empty lines height

### DIFF
--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -105,8 +105,8 @@ namespace AvaloniaEdit.Text
             {
                 var fontSize = paragraphProperties.DefaultTextRunProperties.FontSize;
 
-                Height = fontSize * TextLineRun.HeightFactor;
-                Baseline = fontSize * TextLineRun.BaselineFactor;
+                Height = TextLineRun.GetDefaultLineHeight(fontSize);
+                Baseline = TextLineRun.GetDefaultBaseline(fontSize);
             }
 
             FirstIndex = firstIndex;

--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -103,10 +103,8 @@ namespace AvaloniaEdit.Text
 
             if (Height <= 0)
             {
-                var fontSize = paragraphProperties.DefaultTextRunProperties.FontSize;
-
-                Height = TextLineRun.GetDefaultLineHeight(fontSize);
-                Baseline = TextLineRun.GetDefaultBaseline(fontSize);
+                Height = TextLineRun.GetDefaultLineHeight(paragraphProperties.DefaultTextRunProperties.FontMetrics);
+                Baseline = TextLineRun.GetDefaultBaseline(paragraphProperties.DefaultTextRunProperties.FontMetrics);
             }
 
             FirstIndex = firstIndex;

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -65,11 +65,9 @@ namespace AvaloniaEdit.Text
 
         public static double GetDefaultLineHeight(FontMetrics fontMetrics)
         {
-            // add additional space for underline and line gap
-            return fontMetrics.LineHeight +
-                fontMetrics.UnderlinePosition +
-                fontMetrics.UnderlineThickness + 
-                fontMetrics.LineGap;
+            // adding an extra 15% of the line height look good across different font sizes
+            double extraLineHeight = fontMetrics.LineHeight * 0.15;
+            return fontMetrics.LineHeight + extraLineHeight;
         }
 
         public static double GetDefaultBaseline(FontMetrics fontMetrics)

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -1,14 +1,13 @@
 using System;
 using Avalonia;
 using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
 
 namespace AvaloniaEdit.Text
 {
     internal sealed class TextLineRun
     {
         private const string NewlineString = "\r\n";
-        private const double BaselineFactor = 0.1;
-        private const double HeightFactor = 1.2;
 
         private FormattedText _formattedText;
         private Size _formattedTextSize;
@@ -41,7 +40,8 @@ namespace AvaloniaEdit.Text
                     var box = embeddedObject.ComputeBoundingBox();
                     return box.Y;
                 }
-                return GetDefaultBaseline(FontSize);
+
+                return GetDefaultBaseline(TextRun.Properties.FontMetrics);
             }
         }
 
@@ -59,19 +59,22 @@ namespace AvaloniaEdit.Text
                     return box.Height;
                 }
                 
-                return GetDefaultLineHeight(FontSize);
+                return GetDefaultLineHeight(TextRun.Properties.FontMetrics);
             }
         }
 
-        public static double GetDefaultLineHeight(double fontSize)
+        public static double GetDefaultLineHeight(FontMetrics fontMetrics)
         {
-            // add 2pt for underline
-            return fontSize * HeightFactor + 2;
+            // add additional space for underline and line gap
+            return fontMetrics.LineHeight +
+                fontMetrics.UnderlinePosition +
+                fontMetrics.UnderlineThickness + 
+                fontMetrics.LineGap;
         }
 
-        public static double GetDefaultBaseline(double fontSize)
+        public static double GetDefaultBaseline(FontMetrics fontMetrics)
         {
-            return fontSize * BaselineFactor;
+            return Math.Abs(fontMetrics.Ascent);
         }
 
         public Typeface Typeface => TextRun.Properties.Typeface;

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -7,8 +7,8 @@ namespace AvaloniaEdit.Text
     internal sealed class TextLineRun
     {
         private const string NewlineString = "\r\n";
-        internal const double BaselineFactor = 0.1;
-        internal const double HeightFactor = 1.2;
+        private const double BaselineFactor = 0.1;
+        private const double HeightFactor = 1.2;
 
         private FormattedText _formattedText;
         private Size _formattedTextSize;
@@ -41,7 +41,7 @@ namespace AvaloniaEdit.Text
                     var box = embeddedObject.ComputeBoundingBox();
                     return box.Y;
                 }
-                return FontSize * BaselineFactor;
+                return GetDefaultBaseline(FontSize);
             }
         }
 
@@ -58,9 +58,20 @@ namespace AvaloniaEdit.Text
                     var box = embeddedObject.ComputeBoundingBox();
                     return box.Height;
                 }
-                // add 2pt for underline
-                return FontSize * HeightFactor + 2;
+                
+                return GetDefaultLineHeight(FontSize);
             }
+        }
+
+        public static double GetDefaultLineHeight(double fontSize)
+        {
+            // add 2pt for underline
+            return fontSize * HeightFactor + 2;
+        }
+
+        public static double GetDefaultBaseline(double fontSize)
+        {
+            return fontSize * BaselineFactor;
         }
 
         public Typeface Typeface => TextRun.Properties.Typeface;

--- a/src/AvaloniaEdit/Text/TextRunProperties.cs
+++ b/src/AvaloniaEdit/Text/TextRunProperties.cs
@@ -1,33 +1,97 @@
 ﻿using System.Globalization;
 using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
 
 namespace AvaloniaEdit.Text
 {
     public class TextRunProperties
     {
-        public TextRunProperties Clone() => new TextRunProperties
+        private IBrush _backgroundBrush;
+        private CultureInfo _cultureInfo;
+        private IBrush _foregroundBrush;
+        private Typeface _typeface;
+        private double _fontSize;
+        private FontMetrics _fontMetrics;
+        private bool _underline;
+        private bool _strikethrough;
+
+        public TextRunProperties Clone()
         {
-            BackgroundBrush = BackgroundBrush,
-            CultureInfo = CultureInfo,
-            ForegroundBrush = ForegroundBrush,
-            Typeface = Typeface,
-            FontSize = FontSize,
-            Underline = Underline,
-            Strikethrough = Strikethrough,
-        };
+            TextRunProperties clone = new TextRunProperties();
 
-        public IBrush BackgroundBrush { get; set; }
+            clone._backgroundBrush = BackgroundBrush;
+            clone._cultureInfo = CultureInfo;
+            clone._foregroundBrush = ForegroundBrush;
+            clone._typeface = Typeface;
+            clone._fontSize = FontSize;
+            clone._fontMetrics = FontMetrics;
+            clone._underline = Underline;
+            clone._strikethrough = Strikethrough;
 
-        public CultureInfo CultureInfo { get; set; }
+            return clone;
+        }
 
-        public IBrush ForegroundBrush { get; set; }
+        public IBrush BackgroundBrush
+        {
+            get { return _backgroundBrush; }
+            set { _backgroundBrush = value; }
+        }
 
-        public Typeface Typeface { get; set; }
+        public CultureInfo CultureInfo
+        {
+            get { return _cultureInfo; }
+            set { _cultureInfo = value; }
+        }
 
-        public double FontSize { get; set; }
+        public IBrush ForegroundBrush
+        {
+            get { return _foregroundBrush; }
+            set { _foregroundBrush = value; }
+        }
 
-        public bool Underline { get; set; }
+        public Typeface Typeface
+        {
+            get { return _typeface; }
+            set
+            {
+                _typeface = value;
+                InvalidateFontMetrics();
+            }
+        }
 
-        public bool Strikethrough { get; set; }
+        public double FontSize
+        {
+            get { return _fontSize; }
+            set
+            {
+                _fontSize = value;
+                InvalidateFontMetrics();
+            }
+        }
+
+        public bool Underline
+        {
+            get{ return _underline; }
+            set { _underline = value; }
+        }
+
+        public bool Strikethrough
+        {
+            get { return _strikethrough; }
+            set { _strikethrough = value; }
+        }
+
+        public FontMetrics FontMetrics
+        {
+            get { return _fontMetrics; }
+        }
+
+        void InvalidateFontMetrics()
+        {
+            if (_typeface.FontFamily == null || _fontSize == 0)
+                return;
+
+            _fontMetrics = new FontMetrics(_typeface, _fontSize);
+        }
     }
 }

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/MockFontManagerImpl.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/MockFontManagerImpl.cs
@@ -1,0 +1,43 @@
+﻿using Avalonia.Media;
+using Avalonia.Platform;
+
+using Moq;
+
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace AvaloniaEdit.AvaloniaMocks
+{
+    public class MockFontManagerImpl : IFontManagerImpl
+    {
+        private readonly string _defaultFamilyName;
+
+        public MockFontManagerImpl(string defaultFamilyName = "Default")
+        {
+            _defaultFamilyName = defaultFamilyName;
+        }
+
+        public string GetDefaultFontFamilyName()
+        {
+            return _defaultFamilyName;
+        }
+
+        public IEnumerable<string> GetInstalledFontFamilyNames(bool checkForUpdates = false)
+        {
+            return new[] { _defaultFamilyName };
+        }
+
+        public bool TryMatchCharacter(int codepoint, FontStyle fontStyle, FontWeight fontWeight, FontFamily fontFamily,
+            CultureInfo culture, out Typeface fontKey)
+        {
+            fontKey = new Typeface(_defaultFamilyName);
+
+            return false;
+        }
+
+        public IGlyphTypefaceImpl CreateGlyphTypeface(Typeface typeface)
+        {
+            return new MockGlyphTypeface();
+        }
+    }
+}

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/MockGlyphTypeface.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/MockGlyphTypeface.cs
@@ -1,0 +1,48 @@
+﻿using Avalonia.Platform;
+
+using System;
+
+namespace AvaloniaEdit.AvaloniaMocks
+{
+    public class MockGlyphTypeface : IGlyphTypefaceImpl
+    {
+        public short DesignEmHeight => 10;
+        public int Ascent => 2;
+        public int Descent => 10;
+        public int LineGap { get; }
+        public int UnderlinePosition { get; }
+        public int UnderlineThickness { get; }
+        public int StrikethroughPosition { get; }
+        public int StrikethroughThickness { get; }
+        public bool IsFixedPitch { get; }
+
+        public ushort GetGlyph(uint codepoint)
+        {
+            return 0;
+        }
+
+        public ushort[] GetGlyphs(ReadOnlySpan<uint> codepoints)
+        {
+            return new ushort[codepoints.Length];
+        }
+
+        public int GetGlyphAdvance(ushort glyph)
+        {
+            return 8;
+        }
+
+        public int[] GetGlyphAdvances(ReadOnlySpan<ushort> glyphs)
+        {
+            var advances = new int[glyphs.Length];
+
+            for (var i = 0; i < advances.Length; i++)
+            {
+                advances[i] = 8;
+            }
+
+            return advances;
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/TestServices.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/TestServices.cs
@@ -74,7 +74,8 @@ namespace AvaloniaEdit.AvaloniaMocks
             IPlatformThreadingInterface threadingInterface = null,
             IWindowImpl windowImpl = null,
             IWindowingPlatform windowingPlatform = null,
-            PlatformHotkeyConfiguration platformHotkeyConfiguration = null)
+            PlatformHotkeyConfiguration platformHotkeyConfiguration = null,
+            IFontManagerImpl fontManagerImpl = null)
         {
             AssetLoader = assetLoader;
             FocusManager = focusManager;
@@ -93,6 +94,7 @@ namespace AvaloniaEdit.AvaloniaMocks
             WindowImpl = windowImpl;
             WindowingPlatform = windowingPlatform;
             PlatformHotkeyConfiguration = platformHotkeyConfiguration;
+            FontManagerImpl = fontManagerImpl;
         }
 
         public IAssetLoader AssetLoader { get; }
@@ -112,6 +114,7 @@ namespace AvaloniaEdit.AvaloniaMocks
         public IWindowImpl WindowImpl { get; }
         public IWindowingPlatform WindowingPlatform { get; }
         public PlatformHotkeyConfiguration PlatformHotkeyConfiguration { get; }
+        public IFontManagerImpl FontManagerImpl { get; }
 
         public TestServices With(
             IAssetLoader assetLoader = null,
@@ -130,7 +133,9 @@ namespace AvaloniaEdit.AvaloniaMocks
             Func<Styles> theme = null,
             IPlatformThreadingInterface threadingInterface = null,
             IWindowImpl windowImpl = null,
-            IWindowingPlatform windowingPlatform = null)
+            IWindowingPlatform windowingPlatform = null,
+            PlatformHotkeyConfiguration platformHotkeyConfiguration = null,
+            IFontManagerImpl fontManagerImpl = null)
         {
             return new TestServices(
                 assetLoader: assetLoader ?? AssetLoader,
@@ -148,7 +153,9 @@ namespace AvaloniaEdit.AvaloniaMocks
                 theme: theme ?? Theme,
                 threadingInterface: threadingInterface ?? ThreadingInterface,
                 windowingPlatform: windowingPlatform ?? WindowingPlatform,
-                windowImpl: windowImpl ?? WindowImpl);
+                windowImpl: windowImpl ?? WindowImpl,
+                platformHotkeyConfiguration: platformHotkeyConfiguration ?? PlatformHotkeyConfiguration,
+                fontManagerImpl: fontManagerImpl ?? FontManagerImpl);
         }
 
         private static Styles CreateDefaultTheme()

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/UnitTestApplication.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/UnitTestApplication.cs
@@ -56,7 +56,8 @@ namespace AvaloniaEdit.AvaloniaMocks
                 .Bind<ICursorFactory>().ToConstant(Services.StandardCursorFactory)
                 .Bind<IStyler>().ToConstant(Services.Styler)
                 .Bind<IWindowingPlatform>().ToConstant(Services.WindowingPlatform)
-                .Bind<PlatformHotkeyConfiguration>().ToConstant(Services.PlatformHotkeyConfiguration);
+                .Bind<PlatformHotkeyConfiguration>().ToConstant(Services.PlatformHotkeyConfiguration)
+                .Bind<IFontManagerImpl>().ToConstant(Services.FontManagerImpl);
             var styles = Services.Theme?.Invoke();
 
             if (styles != null)

--- a/test/AvaloniaEdit.Tests/Editing/ChangeDocumentTests.cs
+++ b/test/AvaloniaEdit.Tests/Editing/ChangeDocumentTests.cs
@@ -32,7 +32,8 @@ namespace AvaloniaEdit.Editing
             using (UnitTestApplication.Start(new TestServices(
                 renderInterface: new MockPlatformRenderInterface(),
                 platform: new MockRuntimePlatform(),
-                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration())))
+                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration(),
+                fontManagerImpl: new MockFontManagerImpl())))
             {
                 TextArea textArea = new TextArea();
                 textArea.Document = new TextDocument("1\n2\n3\n4th line");
@@ -51,7 +52,8 @@ namespace AvaloniaEdit.Editing
             using (UnitTestApplication.Start(new TestServices(
                 renderInterface: new MockPlatformRenderInterface(),
                 platform: new MockRuntimePlatform(),
-                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration())))
+                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration(),
+                fontManagerImpl: new MockFontManagerImpl())))
             {
                 TextArea textArea = new TextArea();
                 textArea.Document = new TextDocument("1\n2\n3\n4th line");
@@ -70,7 +72,8 @@ namespace AvaloniaEdit.Editing
             using (UnitTestApplication.Start(new TestServices(
                 renderInterface: new MockPlatformRenderInterface(),
                 platform: new MockRuntimePlatform(),
-                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration())))
+                platformHotkeyConfiguration: new MockPlatformHotkeyConfiguration(),
+                fontManagerImpl: new MockFontManagerImpl())))
             {
                 TextArea textArea = new TextArea();
                 TextDocument newDocument = new TextDocument();


### PR DESCRIPTION
This PR makes empty lines have the same height normal lines have.

### Problem explanation
AvaloniaEdit assigned different heights for empty lines and nonempty lines.
![image](https://user-images.githubusercontent.com/501613/143675923-a8446b85-f614-4ee4-ba5c-ac24134d9db6.png)

The reason is that when creating TextLines with no runs (empty lines), the **extra +2 pixels for underlining was not being added**.

### How I fixed it
Refactored how LineHeight and BaseLine values are calculated to a commonplace, and use the same source code when calculating the height for empty and for non-empty lines.