### PR TITLE
Ignore empty line copy

### DIFF
--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -427,6 +427,8 @@ namespace AvaloniaEdit.Editing
         {
             ISegment wholeLine = new SimpleSegment(line.Offset, line.TotalLength);
             var text = textArea.Document.GetText(wholeLine);
+            // Ignore empty line copy
+            if(string.IsNullOrEmpty(text)) return false;
             // Ensure we use the appropriate newline sequence for the OS
             text = TextUtilities.NormalizeNewLines(text, Environment.NewLine);
 


### PR DESCRIPTION
if text is empty should not be copied, "\n" is not empty string so it will copied.