### PR TITLE
You should be able to move caret by right clicking text area

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -44,12 +44,20 @@ namespace AvaloniaEdit.Demo
             _textEditor = this.FindControl<TextEditor>("Editor");
             _textEditor.Background = Brushes.Transparent;
             _textEditor.ShowLineNumbers = true;
-
+            _textEditor.ContextMenu = new ContextMenu 
+            { 
+                Items = new List<MenuItem> 
+                { 
+                    new MenuItem { Header = "Copy", InputGesture = new KeyGesture(Key.C, KeyModifiers.Control) },
+                    new MenuItem { Header = "Paste", InputGesture = new KeyGesture(Key.V, KeyModifiers.Control) },
+                    new MenuItem { Header = "Cut", InputGesture = new KeyGesture(Key.X, KeyModifiers.Control) }
+                } 
+            };
             _textEditor.TextArea.Background = this.Background;
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy();
-            _textEditor.TextArea.IsRightClickMovesCaret = true;
+            _textEditor.TextArea.RightClickMovesCaret = true;
             _addControlBtn = this.FindControl<Button>("addControlBtn");
             _addControlBtn.Click += _addControlBtn_Click;
 

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -49,7 +49,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy();
-
+            _textEditor.TextArea.IsRightClickMovesCaret = false;
             _addControlBtn = this.FindControl<Button>("addControlBtn");
             _addControlBtn.Click += _addControlBtn_Click;
 

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -49,7 +49,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy();
-            _textEditor.TextArea.IsRightClickMovesCaret = false;
+            _textEditor.TextArea.IsRightClickMovesCaret = true;
             _addControlBtn = this.FindControl<Button>("addControlBtn");
             _addControlBtn.Click += _addControlBtn_Click;
 

--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -16,13 +16,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using Avalonia;
+using Avalonia.Input;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Utils;
 using System;
 using System.ComponentModel;
 using System.Linq;
-using Avalonia;
-using AvaloniaEdit.Document;
-using AvaloniaEdit.Utils;
-using Avalonia.Input;
 
 namespace AvaloniaEdit.Editing
 {
@@ -392,8 +392,15 @@ namespace AvaloniaEdit.Editing
 
         private void TextArea_MouseLeftButtonDown(object sender, PointerPressedEventArgs e)
         {
-            if (e.GetCurrentPoint(TextArea).Properties.IsLeftButtonPressed)
-            { 
+            if (e.GetCurrentPoint(TextArea).Properties.IsLeftButtonPressed == false)
+            {
+                if (TextArea.IsRightClickMovesCaret == true)
+                {
+                    SetCaretOffsetToMousePosition(e);
+                }
+            }
+            else
+            {
                 TextArea.Cursor = Cursor.Parse("IBeam");
 
                 var pointer = e.GetPointerPoint(TextArea);
@@ -499,7 +506,8 @@ namespace AvaloniaEdit.Editing
                     e.Handled = true;
                 }
             }
-		}
+
+        }
         #endregion
 
         #region LeftButtonClick
@@ -687,7 +695,7 @@ namespace AvaloniaEdit.Editing
             else if (_mode == SelectionMode.WholeWord || _mode == SelectionMode.WholeLine)
             {
                 var newWord = (_mode == SelectionMode.WholeLine) ? GetLineAtMousePosition(e) : GetWordAtMousePosition(e);
-                if (newWord != SimpleSegment.Invalid &&_startWord != null)
+                if (newWord != SimpleSegment.Invalid && _startWord != null)
                 {
                     TextArea.Selection = Selection.Create(TextArea,
                                                           Math.Min(newWord.Offset, _startWord.Offset),

--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -394,7 +394,7 @@ namespace AvaloniaEdit.Editing
         {
             if (e.GetCurrentPoint(TextArea).Properties.IsLeftButtonPressed == false)
             {
-                if (TextArea.IsRightClickMovesCaret == true)
+                if (TextArea.RightClickMovesCaret == true && e.Handled == false)
                 {
                     SetCaretOffsetToMousePosition(e);
                 }

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -710,18 +710,18 @@ namespace AvaloniaEdit.Editing
         }
 
         /// <summary>
-        /// The <see cref="IsRightClickMovesCaret"/> property.
+        /// The <see cref="RightClickMovesCaret"/> property.
         /// </summary>
-        public static readonly StyledProperty<bool> IsRightClickMovesCaretProperty =
-            AvaloniaProperty.Register<TextArea, bool>(nameof(IsRightClickMovesCaret), false);
+        public static readonly StyledProperty<bool> RightClickMovesCaretProperty =
+            AvaloniaProperty.Register<TextArea, bool>(nameof(RightClickMovesCaret), false);
 
         /// <summary>
         /// Determines whether caret position should be changed to the mouse position when you right click or not.
         /// </summary>
-        public bool IsRightClickMovesCaret
+        public bool RightClickMovesCaret
         {
-            get => GetValue(IsRightClickMovesCaretProperty);
-            set => SetValue(IsRightClickMovesCaretProperty, value);
+            get => GetValue(RightClickMovesCaretProperty);
+            set => SetValue(RightClickMovesCaretProperty, value);
         }
         #endregion
 

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -708,6 +708,21 @@ namespace AvaloniaEdit.Editing
             get => _readOnlySectionProvider;
             set => _readOnlySectionProvider = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        /// <summary>
+        /// The <see cref="IsRightClickMovesCaret"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> IsRightClickMovesCaretProperty =
+            AvaloniaProperty.Register<TextArea, bool>(nameof(IsRightClickMovesCaret), false);
+
+        /// <summary>
+        /// Determines whether caret position should be changed to the mouse position when you right click or not.
+        /// </summary>
+        public bool IsRightClickMovesCaret
+        {
+            get => GetValue(IsRightClickMovesCaretProperty);
+            set => SetValue(IsRightClickMovesCaretProperty, value);
+        }
         #endregion
 
         #region Focus Handling (Show/Hide Caret)


### PR DESCRIPTION
Originally it was requested by @danipen 
This feature is not present in the original AvaloniaEdit but it would not be bad if we add that IMO. It is what 90% of text editors do.