### PR TITLE
Fix triple click

### DIFF
--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -410,7 +410,7 @@ namespace AvaloniaEdit.Editing
                 {
                     var modifiers = e.KeyModifiers;
                     var shift = modifiers.HasFlag(KeyModifiers.Shift);
-                    if (_enableTextDragDrop && !shift)
+                    if (_enableTextDragDrop && e.ClickCount == 1 && !shift)
                     {
                         var offset = GetOffsetFromMousePosition(e, out _, out _);
                         if (TextArea.Selection.Contains(offset))


### PR DESCRIPTION
Triple-click should select the whole line but before this PR it wasn't working.
**Note**: this code is ported from AvalonEdit