### PR TITLE
Improve long lines support

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         MinWidth="500"
         MinHeight="300"
+        Width="950"
         Title="AvaloniaEdit Demo"
         x:Class="AvaloniaEdit.Demo.MainWindow"
         Background="#1E1E1E">
@@ -16,6 +17,9 @@
             <Button Name="clearControlBtn" Content="Clear Buttons" />
             <ComboBox Name="syntaxModeCombo" />
             <Button Name="changeThemeBtn" Content="Change theme"/>
+        </StackPanel>
+        <StackPanel Name="StatusBar" Background="Purple" Height="25" DockPanel.Dock="Bottom" Orientation="Horizontal">
+            <TextBlock Name="StatusText" Text="Ready" Margin="5 0 0 0" VerticalAlignment="Center" FontSize="12"/>
         </StackPanel>
         <AvalonEdit:TextEditor Name="Editor"
                                FontFamily="Consolas,Menlo,Monospace"

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace AvaloniaEdit.Demo
         private Button _clearControlBtn;
         private Button _changeThemeBtn;
         private ComboBox _syntaxModeCombo;
+        private TextBlock _statusTextBlock;
         private ElementGenerator _generator = new ElementGenerator();
         private int _currentTheme = (int)ThemeName.DarkPlus;
 
@@ -49,6 +50,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy();
+            _textEditor.TextArea.Caret.PositionChanged += Caret_PositionChanged;
 
             _addControlBtn = this.FindControl<Button>("addControlBtn");
             _addControlBtn.Click += _addControlBtn_Click;
@@ -77,12 +79,19 @@ namespace AvaloniaEdit.Demo
             _textEditor.Document = new TextDocument(ResourceLoader.LoadSampleFile(scopeName));
             _textMateInstallation.SetGrammarByLanguageId(csharpLanguage.Id);
 
+            _statusTextBlock = this.Find<TextBlock>("StatusText");
+
             this.AddHandler(PointerWheelChangedEvent, (o, i) =>
             {
                 if (i.KeyModifiers != KeyModifiers.Control) return;
                 if (i.Delta.Y > 0) _textEditor.FontSize++;
                 else _textEditor.FontSize = _textEditor.FontSize > 1 ? _textEditor.FontSize - 1 : 1;
             }, RoutingStrategies.Bubble, true);
+        }
+
+        private void Caret_PositionChanged(object sender, EventArgs e)
+        {
+            _statusTextBlock.Text = String.Format("Line {0} Column {1}", _textEditor.TextArea.Caret.Line, _textEditor.TextArea.Caret.Column);
         }
 
         protected override void OnClosed(EventArgs e)

--- a/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
+++ b/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="TextMateSharp" Version="1.0.13" />
+    <PackageReference Include="TextMateSharp" Version="1.0.14" />
   </ItemGroup>
 
 </Project>

--- a/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
@@ -81,6 +81,10 @@ namespace AvaloniaEdit.Rendering
 		/// <inheritdoc/>
 		public override int GetFirstInterestedOffset(int startOffset)
 		{
+			if (startOffset > VisualLine.LENGTH_LIMIT)
+				// do not process long lines
+				return -1;
+
 			GetMatch(startOffset, out var matchOffset);
 			return matchOffset;
 		}

--- a/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
@@ -81,10 +81,6 @@ namespace AvaloniaEdit.Rendering
 		/// <inheritdoc/>
 		public override int GetFirstInterestedOffset(int startOffset)
 		{
-			if (startOffset > VisualLine.LENGTH_LIMIT)
-				// do not process long lines
-				return -1;
-
 			GetMatch(startOffset, out var matchOffset);
 			return matchOffset;
 		}

--- a/src/AvaloniaEdit/Rendering/VisualLine.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLine.cs
@@ -37,6 +37,8 @@ namespace AvaloniaEdit.Rendering
     /// </summary>
     public sealed class VisualLine
     {
+        public const int LENGTH_LIMIT = 3000;
+
         private enum LifetimePhase : byte
         {
             Generating,
@@ -179,7 +181,21 @@ namespace AvaloniaEdit.Rendering
                 if (textPieceEndOffset > offset)
                 {
                     var textPieceLength = textPieceEndOffset - offset;
-                    _elements.Add(new VisualLineText(this, textPieceLength));
+                    int remaining = textPieceLength;
+                    while (true)
+                    {
+                        if (remaining > LENGTH_LIMIT)
+                        {
+                            // split in chunks of LENGTH_LIMIT
+                            _elements.Add(new VisualLineText(this, LENGTH_LIMIT));
+                            remaining -= LENGTH_LIMIT;
+                        }
+                        else
+                        {
+                            _elements.Add(new VisualLineText(this, remaining));
+                            break;
+                        }
+                    }
                     offset = textPieceEndOffset;
                 }
                 // If no elements constructed / only zero-length elements constructed:

--- a/src/AvaloniaEdit/Rendering/VisualLine.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLine.cs
@@ -157,6 +157,7 @@ namespace AvaloniaEdit.Rendering
         private void PerformVisualElementConstruction(VisualLineElementGenerator[] generators)
         {
             var document = Document;
+            var lineLength = FirstDocumentLine.Length;
             var offset = FirstDocumentLine.Offset;
             var currentLineEnd = offset + FirstDocumentLine.Length;
             LastDocumentLine = FirstDocumentLine;
@@ -166,7 +167,7 @@ namespace AvaloniaEdit.Rendering
                 var textPieceEndOffset = currentLineEnd;
                 foreach (var g in generators)
                 {
-                    g.CachedInterest = g.GetFirstInterestedOffset(offset + askInterestOffset);
+                    g.CachedInterest = (lineLength > LENGTH_LIMIT) ? -1: g.GetFirstInterestedOffset(offset + askInterestOffset);
                     if (g.CachedInterest != -1)
                     {
                         if (g.CachedInterest < offset)

--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -9,8 +9,6 @@ namespace AvaloniaEdit.Text
 {
     internal sealed class TextLineImpl : TextLine
     {
-        private const int MaxCharactersPerLine = 10000;
-
         private readonly TextLineRun[] _runs;
 
         public override int FirstIndex { get; }
@@ -47,11 +45,6 @@ namespace AvaloniaEdit.Text
             if (prevRun != null)
             {
                 visibleLength += AddRunReturnVisibleLength(runs, prevRun);
-            }
-
-            if (visibleLength >= MaxCharactersPerLine)
-            {
-                throw new NotSupportedException("Too many characters per line");
             }
 
             while (true)

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Linq;
+
 using Avalonia;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+
+using AvaloniaEdit.Rendering;
 
 namespace AvaloniaEdit.Text
 {
@@ -11,8 +15,7 @@ namespace AvaloniaEdit.Text
 
         private FormattedText _formattedText;
         private Size _formattedTextSize;
-        private double[] _glyphWidths;
-
+        private GlyphWidths _glyphWidths;
         public StringRange StringRange { get; private set; }
 
         public int Length { get; set; }
@@ -109,7 +112,7 @@ namespace AvaloniaEdit.Text
                 return new TextLineRun(textRun.Length, textRun)
                 {
                     IsEmbedded = true,
-                    _glyphWidths = new double[] { width },
+                    _glyphWidths = new GlyphWidths(stringRange, textRun.Properties.Typeface, textRun.Properties.FontSize),
                     // Embedded objects must propagate their width to the container.
                     // Otherwise text runs after the embedded object are drawn at the same x position.
                     Width = width
@@ -162,7 +165,7 @@ namespace AvaloniaEdit.Text
                 Width = 40
             };
 
-            run.SetGlyphWidths();
+            run._glyphWidths = new GlyphWidths(run.StringRange, run.Typeface, run.FontSize);
 
             return run;
         }
@@ -192,7 +195,7 @@ namespace AvaloniaEdit.Text
 
             run.Width = size.Width;
 
-            run.SetGlyphWidths();
+            run._glyphWidths = new GlyphWidths(run.StringRange, run.Typeface, run.FontSize);
 
             return run;
         }
@@ -201,27 +204,6 @@ namespace AvaloniaEdit.Text
         {
             Length = length;
             TextRun = textRun;
-        }
-
-        private void SetGlyphWidths()
-        {
-            var result = new double[StringRange.Length];
-
-            for (var i = 0; i < StringRange.Length; i++)
-            {
-                // TODO: is there a better way of getting glyph metrics?
-                var tf = Typeface;
-                var size = new FormattedText
-                {
-                    Text = StringRange[i].ToString(),
-                    Typeface = new Typeface(tf.FontFamily, tf.Style, tf.Weight),
-                    FontSize = FontSize
-                }.Bounds.Size;
-
-                result[i] = size.Width;
-            }
-
-            _glyphWidths = result;
         }
 
         public void Draw(DrawingContext drawingContext, double x, double y)
@@ -290,7 +272,7 @@ namespace AvaloniaEdit.Text
             {
                 while (index > 0 && IsSpace(StringRange[index - 1]))
                 {
-                    trailing.SpaceWidth += _glyphWidths[index - 1];
+                    trailing.SpaceWidth += _glyphWidths.GetAt(index - 1);
                     index--;
                     trailing.Count++;
                 }
@@ -313,7 +295,7 @@ namespace AvaloniaEdit.Text
                 double distance = 0;
                 for (var i = 0; i < index; i++)
                 {
-                    distance += _glyphWidths[i];
+                    distance += _glyphWidths.GetAt(i);
                 }
 
                 return distance;
@@ -332,7 +314,7 @@ namespace AvaloniaEdit.Text
             double width = 0;
             for (; index < Length; index++)
             {
-                width = IsTab ? Width / Length : _glyphWidths[index];
+                width = IsTab ? Width / Length : _glyphWidths.GetAt(index);
                 if (distance < width)
                 {
                     break;
@@ -349,6 +331,59 @@ namespace AvaloniaEdit.Text
         private static bool IsSpace(char ch)
         {
             return ch == ' ' || ch == '\u00a0';
+        }
+
+        class GlyphWidths
+        {
+            private const double NOT_CALCULATED_YET = -1;
+            private double[] _glyphWidths;
+            private Typeface _typeFace;
+            private double _fontSize;
+            private StringRange _range;
+
+            internal GlyphWidths(StringRange range, Typeface typeFace, double fontSize)
+            {
+                _typeFace = typeFace;
+                _fontSize = fontSize;
+                _range = range;
+
+                _glyphWidths = InitGlyphWidths();
+            }
+
+            internal double GetAt(int index)
+            {
+                if (_glyphWidths[index] == NOT_CALCULATED_YET)
+                    _glyphWidths[index] = MeasureGlyphAt(index);
+
+                return _glyphWidths[index];
+            }
+
+            double MeasureGlyphAt(int index)
+            {
+                return new FormattedText
+                {
+                    Text = _range[index].ToString(),
+                    Typeface = _typeFace,
+                    FontSize = _fontSize,
+                }.Bounds.Width;
+            }
+
+            double[] InitGlyphWidths()
+            {
+                int capacity = _range.Length;
+
+                bool useCheapGlyphMeasurement = 
+                    capacity >= VisualLine.LENGTH_LIMIT && 
+                    _typeFace.GlyphTypeface.IsFixedPitch;
+
+                if (useCheapGlyphMeasurement)
+                {
+                    double size = MeasureGlyphAt(0);
+                    return Enumerable.Repeat<double>(size, capacity).ToArray();
+                }
+
+                return Enumerable.Repeat<double>(NOT_CALCULATED_YET, capacity).ToArray();
+            }
         }
     }
 }


### PR DESCRIPTION
**This PR allows AvaloniaEdit to handle long lines with acceptable performance.** 

Before this PR, AvaloniaEdit only supported lines no longer than 10.000 characters. If a line in the document was longer than 10.000 characters, an exception was raised.

### Previous issues handling long lines
Before this PR, removing that restriction, AvaloniaEdit is able to display longer lines, but some issues appear:
- The TextMate tokenizer was slow for super long lines.
- Editing, navigating, selecting text, etc ... was quite slow.
- There is a accumulated error between the position a glyph is drawn and the position the caret is.
- In general performance was quite bad with really long lines (>250.000) characters.

### Changes made to support long lines
I made several changes to better support very long lines:
- **Fixed the accumulated error between the glyph position and the caret position:** Avalonia's `FormattedText `measuring accumulates error when measuring glyphs approx above index 3000. Splitting the VisualLine in chunks of 3000 characters fixes the issue.
- **Disable the `VisualLineElementGenerators` for long lines**: Some generators, such as the one that detects email addresses or hyperlinks that let the user click to open the link, performed badly with long lines because they use regular expressions.
- **Calculate glyph widths under demand and use cheap measurement for long lines**: 
  1) Do not calculate all the glyph widths at the beginning. Calculating them under demand allows us to improve performance thanks to the virtualization of the ScrollViewer.
  2) Measure each glyph for long lines kills performance. So, as an improvement, when using a monospaced font, if we detect a long chunk (>3000 characters), just assign the same width for all glyphs.
- **Update to TextmateSharp 1.0.14**: This version only tokenizes the first 10.000 characters of each line, which is enough for most cases.

### Demo video handling long lines
I created a file with a really huge line (~5 million column). After this PR changes, AvaloniaEdit is able to deal with it.

https://user-images.githubusercontent.com/501613/146963282-f1e4915c-73ea-4260-b031-a1aba126f335.mov


