### PR TITLE
Update TextMateSharp to v1.0.15

### DIFF
--- a/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
+++ b/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="TextMateSharp" Version="1.0.14" />
+    <PackageReference Include="TextMateSharp" Version="1.0.15" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
If fixes a NRE exception when trying to revalidate tokens when the tokenizer is still null.