### PR TITLE
Fix embedded runs baseline

### DIFF
--- a/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
@@ -142,7 +142,7 @@ namespace AvaloniaEdit.Rendering
             }
         }
 
-        private sealed class TabTextElement : VisualLineElement
+        internal sealed class TabTextElement : VisualLineElement
         {
             internal readonly TextLine Text;
 
@@ -175,7 +175,7 @@ namespace AvaloniaEdit.Rendering
             }
         }
 
-        private sealed class TabGlyphRun : TextEmbeddedObject
+        internal sealed class TabGlyphRun : TextEmbeddedObject
         {
             private readonly TabTextElement _element;
 
@@ -195,8 +195,9 @@ namespace AvaloniaEdit.Rendering
 
             public override Size GetSize(double remainingParagraphWidth)
             {
-                var width = Math.Min(0, _element.Text.WidthIncludingTrailingWhitespace - 1);
-                return new Size(width, _element.Text.Height);
+                return new Size(
+                    _element.Text.WidthIncludingTrailingWhitespace,
+                    _element.Text.Height);
             }
 
             public override Rect ComputeBoundingBox()
@@ -206,7 +207,6 @@ namespace AvaloniaEdit.Rendering
 
             public override void Draw(DrawingContext drawingContext, Point origin)
             {
-                origin = origin.WithY(origin.Y - _element.Text.Baseline);
                 _element.Text.Draw(drawingContext, origin);
             }
         }

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -41,13 +41,16 @@ namespace AvaloniaEdit.Text
                 {
                     return 0.0;
                 }
+
+                double defaultBaseLine = GetDefaultBaseline(TextRun.Properties.FontMetrics);
+
                 if (IsEmbedded && TextRun is TextEmbeddedObject embeddedObject)
                 {
                     var box = embeddedObject.ComputeBoundingBox();
-                    return box.Y;
+                    return defaultBaseLine - box.Y;
                 }
 
-                return GetDefaultBaseline(TextRun.Properties.FontMetrics);
+                return defaultBaseLine;
             }
         }
 

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/MockGlyphTypeface.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/MockGlyphTypeface.cs
@@ -8,10 +8,12 @@ namespace AvaloniaEdit.AvaloniaMocks
     {
         public const int GlyphAdvance = 8;
         public const short DefaultFontSize = 10;
+        public const int GlyphAscent = 2;
+        public const int GlyphDescent = 10;
 
         public short DesignEmHeight => DefaultFontSize;
-        public int Ascent => 2;
-        public int Descent => 10;
+        public int Ascent => GlyphAscent;
+        public int Descent => GlyphDescent;
         public int LineGap { get; }
         public int UnderlinePosition { get; }
         public int UnderlineThickness { get; }

--- a/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
+++ b/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Media;
+﻿using Avalonia;
+using Avalonia.Media;
 using Avalonia.Platform;
 
 using AvaloniaEdit.AvaloniaMocks;
@@ -135,6 +136,79 @@ namespace AvaloniaEdit.Text
             Assert.AreEqual(
                 runWidth + SpecialCharacterTextRun.BoxMargin,
                 run.GetDistanceFromCharacter(1));
+        }
+
+        [Test]
+        public void TextEmbeddedObject_Should_Have_Valid_Baseline()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            int runWidth = 50;
+
+            TextLine textLine = Mock.Of<TextLine>(
+                t => t.WidthIncludingTrailingWhitespace == runWidth);
+
+            SpecialCharacterTextRun f = new SpecialCharacterTextRun(
+                new FormattedTextElement("BEL", 1) { TextLine = textLine },
+                CreateDefaultTextProperties());
+
+            Mock<TextSource> ts = new Mock<TextSource>();
+            ts.Setup(s => s.GetTextRun(It.IsAny<int>())).Returns(f);
+
+            TextLineRun run = TextLineRun.Create(ts.Object, 0, 0, 1, CreateDefaultParagraphProperties());
+
+            Assert.AreEqual(MockGlyphTypeface.GlyphAscent, run.Baseline);
+        }
+
+        [Test]
+        public void Simple_Run_Should_Have_Valid_Baseline()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "a\ta",
+                CreateDefaultTextProperties());
+
+            var paragraphProperties = CreateDefaultParagraphProperties();
+
+            TextLineRun run = TextLineRun.Create(s, 0, 0, 1, paragraphProperties);
+
+            Assert.AreEqual(MockGlyphTypeface.GlyphAscent, run.Baseline);
+        }
+
+        [Test]
+        public void Tab_Glyph_Run_Shuld_Have_Valid_Bounds()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            double runWidth = 50;
+            double runHeight = 20;
+
+            Mock<TextLine> textLineMock = new Mock<TextLine>();
+            textLineMock.Setup(
+                t => t.WidthIncludingTrailingWhitespace).Returns(runWidth);
+            textLineMock.Setup(
+                t => t.Height).Returns(runHeight);
+
+            TabTextElement tabTextElement = new TabTextElement(textLineMock.Object);
+
+            TabGlyphRun tabRun = new TabGlyphRun(
+                tabTextElement,
+                CreateDefaultTextProperties());
+
+            Size runSize = tabRun.GetSize(double.PositiveInfinity);
+
+            Assert.AreEqual(runWidth, runSize.Width, "Wrong run width");
+            Assert.AreEqual(runHeight, runSize.Height, "Wrong run height");
         }
 
         TextRunProperties CreateDefaultTextProperties()


### PR DESCRIPTION
Fixes #191. Now displaying tabs, spaces, or newline characters doesn't add spacing between lines.

Demo (notice I draw the RextRun bounding boxes as debug purposes to ensure that they are correct):

https://user-images.githubusercontent.com/501613/151114591-829ec35a-6186-4a77-b66c-144a380cdc00.mp4
