### PR TITLE
Textmate - support bold, italic and underline font styles

### DIFF
--- a/src/AvaloniaEdit.Demo/Resources/SampleFiles/text.log
+++ b/src/AvaloniaEdit.Demo/Resources/SampleFiles/text.log
@@ -14,6 +14,43 @@
 03/22 08:51:06 INFO   :...read_physical_netif: index #4, interface CTCD0 has address 9.67.116.98, ifidx 4
 03/22 08:51:06 INFO   :...read_physical_netif: index #5, interface CTCD2 has address 9.67.117.98, ifidx 5
 03/22 08:51:06 INFO   :...read_physical_netif: index #6, interface LOOPBACK has address 127.0.0.1, ifidx 0
+03/22 08:51:01 INFO   :.main: *************** RSVP Agent started ***************
+03/22 08:51:01 INFO   :...locate_configFile: Specified configuration file: /u/user10/rsvpd1.conf
+03/22 08:51:01 INFO   :.main: Using log level 511
+03/22 08:51:01 INFO   :..settcpimage: Get TCP images rc - EDC8112I Operation not supported on socket.
+03/22 08:51:01 INFO   :..settcpimage: Associate with TCP/IP image name = TCPCS
+03/22 08:51:02 INFO   :..reg_process: registering process with the system
+03/22 08:51:02 INFO   :..reg_process: attempt OS/390 registration
+03/22 08:51:02 INFO   :..reg_process: return from registration rc=0
+03/22 08:51:06 TRACE  :...read_physical_netif: Home list entries returned = 7
+03/22 08:51:06 INFO   :...read_physical_netif: index #0, interface VLINK1 has address 129.1.1.1, ifidx 0
+03/22 08:51:06 INFO   :...read_physical_netif: index #1, interface TR1 has address 9.37.65.139, ifidx 1
+03/22 08:51:06 INFO   :...read_physical_netif: index #2, interface LINK11 has address 9.67.100.1, ifidx 2
+03/22 08:51:06 INFO   :...read_physical_netif: index #3, interface LINK12 has address 9.67.101.1, ifidx 3
+03/22 08:51:06 INFO   :...read_physical_netif: index #4, interface CTCD0 has address 9.67.116.98, ifidx 4
+03/22 08:51:06 INFO   :...read_physical_netif: index #5, interface CTCD2 has address 9.67.117.98, ifidx 5
+03/22 08:51:06 INFO   :...read_physical_netif: index #6, interface LOOPBACK has address 127.0.0.1, ifidx 0
+03/22 08:51:06 ERROR   :...read_physical_netif: index #6, interface LOOPBACK has address 127.0.0.1, ifidx 0
+ConsoleApplication1.MyCustomException: some message .... ---> System.Exception: Oh noes, something went wrong
+   at ConsoleApplication1.SomeObject.OtherMethod() in C:\ConsoleApplication1\SomeObject.cs:line 24
+   at ConsoleApplication1.SomeObject..ctor() in C:\ConsoleApplication1\SomeObject.cs:line 14
+   at ConsoleApplication1.SomeObject..ctor() in C:\ConsoleApplication1\SomeObject.cs:line 18
+   at ConsoleApplication1.Program.DoSomething() in C:\ConsoleApplication1\Program.cs:line 23
+   at ConsoleApplication1.Program.Main(String[] args) in C:\ConsoleApplication1\Program.cs:line 13
+03/22 08:51:06 INFO   :....mailslot_create: creating mailslot for timer
+03/22 08:51:06 INFO   :...mailbox_register: mailbox allocated for timer
+03/22 08:51:06 INFO   :.....mailslot_create: creating mailslot for RSVP
+03/22 08:51:06 INFO   :....mailbox_register: mailbox allocated for rsvp
+03/22 08:51:06 INFO   :.....mailslot_create: creating mailslot for RSVP via UDP
+03/22 08:51:06 WARNING:.....mailslot_create: setsockopt(MCAST_ADD) failed - EDC8116I Address not available.
+03/22 08:51:06 INFO   :....mailbox_register: mailbox allocated for rsvp-udp
+03/22 08:51:06 TRACE  :..entity_initialize: interface 129.1.1.1, entity for rsvp allocated and initialized
+03/22 08:51:06 INFO   :.....mailslot_create: creating mailslot for RSVP
+03/22 08:51:06 INFO   :....mailbox_register: mailbox allocated for rsvp
+03/22 08:51:06 INFO   :.....mailslot_create: creating mailslot for RSVP via UDP
+03/22 08:51:06 WARNING:.....mailslot_create: setsockopt(MCAST_ADD) failed - EDC8116I Address not available.
+03/22 08:51:06 INFO   :....mailbox_register: mailbox allocated for rsvp-udp
+03/22 08:51:06 TRACE  :..entity_initialize: interface 9.37.65.139, entity for rsvp allocated and 
 03/22 08:51:06 INFO   :....mailslot_create: creating mailslot for timer
 03/22 08:51:06 INFO   :...mailbox_register: mailbox allocated for timer
 03/22 08:51:06 INFO   :.....mailslot_create: creating mailslot for RSVP

--- a/src/AvaloniaEdit.TextMate/GenericLineTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/GenericLineTransformer.cs
@@ -1,6 +1,4 @@
 using Avalonia.Media;
-using Avalonia.Media.Immutable;
-
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Rendering;
 
@@ -15,8 +13,19 @@ namespace AvaloniaEdit.TextMate
 
         protected abstract void TransformLine(DocumentLine line, ITextRunConstructionContext context);
 
-        public void SetTextOpacity(DocumentLine line, int startIndex, int length, double opacity)
+        public void SetTextStyle(
+            DocumentLine line,
+            int startIndex,
+            int length,
+            IBrush foreground,
+            IBrush background,
+            FontStyle fontStyle, 
+            FontWeight fontWeigth, 
+            bool isUnderline)
         {
+            int startOffset = 0;
+            int endOffset = 0;
+
             if (startIndex >= 0 && length > 0)
             {
                 if ((line.Offset + startIndex + length) > line.EndOffset)
@@ -24,53 +33,48 @@ namespace AvaloniaEdit.TextMate
                     length = (line.EndOffset - startIndex) - line.Offset - startIndex;
                 }
 
-                int startOffset = line.Offset + startIndex;
-                int endoffset = line.Offset + startIndex + length;
-
-                if (startOffset < CurrentContext.Document.TextLength && endoffset < CurrentContext.Document.TextLength)
-                {
-                    ChangeLinePart(startOffset, endoffset, e =>
-                    {
-                        if (e.TextRunProperties.ForegroundBrush is ISolidColorBrush solidBrush)
-                        {
-                            e.TextRunProperties.ForegroundBrush = new ImmutableSolidColorBrush(solidBrush.Color, opacity);
-                        }
-                    });
-                }
+                startOffset = line.Offset + startIndex;
+                endOffset = line.Offset + startIndex + length;
             }
             else
             {
-                ChangeLinePart(line.Offset, line.EndOffset, e =>
-                {
-                    if (e.TextRunProperties.ForegroundBrush is ISolidColorBrush solidBrush)
-                    {
-                        e.TextRunProperties.ForegroundBrush = new ImmutableSolidColorBrush(solidBrush.Color, opacity);
-                    }
-                });
+                startOffset = line.Offset;
+                endOffset = line.EndOffset;
             }
+
+            if (startOffset > CurrentContext.Document.TextLength ||
+                endOffset > CurrentContext.Document.TextLength)
+                return;
+
+            ChangeLinePart(
+                startOffset,
+                endOffset,
+                visualLine => ChangeVisualLine(visualLine, foreground, background, fontStyle, fontWeigth, isUnderline));
         }
 
-        public void SetTextStyle(DocumentLine line, int startIndex, int length, IBrush foreground)
+        void ChangeVisualLine(
+            VisualLineElement visualLine,
+            IBrush foreground,
+            IBrush background,
+            FontStyle fontStyle,
+            FontWeight fontWeigth,
+            bool isUnderline)
         {
-            if (startIndex >= 0 && length > 0)
-            {
-                if ((line.Offset + startIndex + length) > line.EndOffset)
-                {
-                    length = (line.EndOffset - startIndex) - line.Offset - startIndex;
-                }
+            if (foreground != null)
+                visualLine.TextRunProperties.ForegroundBrush = foreground;
 
-                int startOffset = line.Offset + startIndex;
-                int endoffset = line.Offset + startIndex + length;
+            if (background != null)
+                visualLine.TextRunProperties.BackgroundBrush = background;
 
-                if (startOffset < CurrentContext.Document.TextLength && endoffset < CurrentContext.Document.TextLength)
-                {
-                    ChangeLinePart(startOffset, endoffset, e => { e.TextRunProperties.ForegroundBrush = foreground; });
-                }
-            }
-            else
+            visualLine.TextRunProperties.Underline = isUnderline;
+
+            if (visualLine.TextRunProperties.Typeface.Style != fontStyle ||
+                visualLine.TextRunProperties.Typeface.Weight != fontWeigth)
             {
-                ChangeLinePart(line.Offset, line.EndOffset, e => { e.TextRunProperties.ForegroundBrush = foreground; });
+                visualLine.TextRunProperties.Typeface = new Typeface(
+                    visualLine.TextRunProperties.Typeface.FontFamily, fontStyle, fontWeigth);
             }
+
         }
     }
 }

--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -92,18 +92,12 @@ namespace AvaloniaEdit.TextMate
             }
         }
 
-        bool ForegroundTextTransformation.IColorMap.Contains(int foregroundColor)
+        IBrush ForegroundTextTransformation.IColorMap.GetBrush(int colorId)
         {
             if (_brushes == null)
-                return false;
+                return null;
 
-            return _brushes.ContainsKey(foregroundColor);
-        }
-
-        IBrush ForegroundTextTransformation.IColorMap.GetBrush(int color)
-        {
-            IBrush result = null;
-            _brushes.TryGetValue(color, out result);
+            _brushes.TryGetValue(colorId, out IBrush result);
             return result;
         }
 

--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -100,9 +100,11 @@ namespace AvaloniaEdit.TextMate
             return _brushes.ContainsKey(foregroundColor);
         }
 
-        IBrush ForegroundTextTransformation.IColorMap.GetForegroundBrush(int foregroundColor)
+        IBrush ForegroundTextTransformation.IColorMap.GetBrush(int color)
         {
-            return _brushes[foregroundColor];
+            IBrush result = null;
+            _brushes.TryGetValue(color, out result);
+            return result;
         }
 
         protected override void TransformLine(DocumentLine line, ITextRunConstructionContext context)
@@ -142,16 +144,24 @@ namespace AvaloniaEdit.TextMate
 
                 var lineOffset = _document.GetLineByNumber(lineNumber).Offset;
 
+                int foreground = 0;
+                int background = 0;
+                int fontStyle = 0;
+
                 foreach (var themeRule in _theme.Match(token.Scopes))
                 {
-                    if (themeRule.foreground > 0 && _brushes.ContainsKey(themeRule.foreground))
-                    {
-                        _transformations.Add(new ForegroundTextTransformation(this, lineOffset + startIndex,
-                            lineOffset + endIndex, themeRule.foreground));
+                    if (foreground == 0 && themeRule.foreground > 0)
+                        foreground =  themeRule.foreground;
 
-                        break;
-                    }
+                    if (background == 0 && themeRule.background > 0)
+                        background = themeRule.background;
+
+                    if (fontStyle == 0 && themeRule.fontStyle > 0)
+                        fontStyle = themeRule.fontStyle;
                 }
+
+                _transformations.Add(new ForegroundTextTransformation(this, lineOffset + startIndex,
+                    lineOffset + endIndex, foreground, background, fontStyle));
             }
         }
 

--- a/src/AvaloniaEdit.TextMate/TextTransformation.cs
+++ b/src/AvaloniaEdit.TextMate/TextTransformation.cs
@@ -24,25 +24,24 @@ namespace AvaloniaEdit.TextMate
     {
         public interface IColorMap
         {
-            bool Contains(int color);
             IBrush GetBrush(int color);
         }
 
-        int _foregroundBrushId;
-        int _backgroundBrushId;
+        int _foreground;
+        int _background;
         int _fontStyle;
 
         public ForegroundTextTransformation(
             IColorMap colorMap,
             int startOffset,
             int endOffset,
-            int foregroundBrushId,
-            int backgroundBrushId,
+            int foreground,
+            int background,
             int fontStyle) : base(startOffset, endOffset)
         {
             _colorMap = colorMap;
-            _foregroundBrushId = foregroundBrushId;
-            _backgroundBrushId = backgroundBrushId;
+            _foreground = foreground;
+            _background = background;
             _fontStyle = fontStyle;
         }
 
@@ -67,8 +66,8 @@ namespace AvaloniaEdit.TextMate
             }
 
                 transformer.SetTextStyle(line, formattedOffset, endOffset - line.Offset - formattedOffset,
-                _colorMap.GetBrush(_foregroundBrushId),
-                _colorMap.GetBrush(_backgroundBrushId),
+                _colorMap.GetBrush(_foreground),
+                _colorMap.GetBrush(_background),
                 GetFontStyle(),
                 GetFontWeight(),
                 IsUnderline());


### PR DESCRIPTION
This PR enables TextMate integration to draw bold, italic, or underline font for certain tokens. 

Some examples:

### Main titles in markdown grammar use bold text:
![image](https://user-images.githubusercontent.com/501613/151200213-e4d21329-ed84-42f6-be5b-bd4f813af371.png)

### Stack traces in log grammar use italic text:
![image](https://user-images.githubusercontent.com/501613/151200563-9ae3d8a5-1e4d-454a-b378-c420e3f66f27.png)

This PR also fixes an index in the `GenericLineTransformer.cs` that prevented to colorize the last line in the document.