### PR TITLE
Update to TextMateSharp 1.0.24

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AvaloniaVersion>0.10.12</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.23</TextMateSharpVersion>
+    <TextMateSharpVersion>1.0.24</TextMateSharpVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
 	<Version>0.10.12.1</Version>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #199.

When the `TextEditorModel` reports a certain number of lines and the TextMate tokenizer thread tries to parse a line that not is in the range reported by the `TextEditorModel` ([0-TextEditorModel.GetNumberOfLines()), it caused an IndexOutOfRangeException in TextMateSharp. 

This was fixed in TextMateSharp 1.0.24. This PR update the dep to that version.