### PR TITLE
Fix word wrap

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window xmlns="https://github.com/avaloniaui"
         xmlns:AvalonEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        MinWidth="500"
+        MinWidth="0"
         MinHeight="300"
         Width="950"
         Title="AvaloniaEdit Demo"
@@ -12,7 +12,11 @@
                     DockPanel.Dock="Top"
                     Spacing="5"
                     Margin="3">
-            <Button Content="Copy" />
+            <ToggleButton Name="wordWrap" ToolTip.Tip="Word wrap" IsChecked="{Binding #Editor.WordWrap}">
+                <ToggleButton.Content>
+                    <Path Fill="White" Data="M2.75 5C2.33579 5 2 5.33579 2 5.75C2 6.16421 2.33579 6.5 2.75 6.5H21.25C21.6642 6.5 22 6.16421 22 5.75C22 5.33579 21.6642 5 21.25 5H2.75Z M2.75 11.5C2.33579 11.5 2 11.8358 2 12.25C2 12.6642 2.33579 13 2.75 13H19C20.3807 13 21.5 14.1193 21.5 15.5C21.5 16.8807 20.3807 18 19 18H14.5607L15.2803 17.2803C15.5732 16.9874 15.5732 16.5126 15.2803 16.2197C14.9874 15.9268 14.5126 15.9268 14.2197 16.2197L12.2197 18.2197C11.9268 18.5126 11.9268 18.9874 12.2197 19.2803L14.2197 21.2803C14.5126 21.5732 14.9874 21.5732 15.2803 21.2803C15.5732 20.9874 15.5732 20.5126 15.2803 20.2197L14.5607 19.5H19C21.2091 19.5 23 17.7091 23 15.5C23 13.2909 21.2091 11.5 19 11.5H2.75Z M2 18.75C2 18.3358 2.33579 18 2.75 18H9.25C9.66421 18 10 18.3358 10 18.75C10 19.1642 9.66421 19.5 9.25 19.5H2.75C2.33579 19.5 2 19.1642 2 18.75Z" />
+                </ToggleButton.Content>
+            </ToggleButton>
             <Button Name="addControlBtn" Content="Add Button" />
             <Button Name="clearControlBtn" Content="Clear Buttons" />
             <ComboBox Name="syntaxModeCombo" />

--- a/src/AvaloniaEdit/Text/StringRange.cs
+++ b/src/AvaloniaEdit/Text/StringRange.cs
@@ -6,7 +6,7 @@ namespace AvaloniaEdit.Text
     {
         public string String { get; }
 
-        public int Length { get; }
+        public int Length { get; set; }
 
         public static StringRange Empty => default(StringRange);
 
@@ -23,11 +23,12 @@ namespace AvaloniaEdit.Text
 
         public override string ToString()
         {
-            if (String == null) return string.Empty;
+            return ToString(String, OffsetToFirstChar, Length);
+        }
 
-            if (OffsetToFirstChar == 0 && Length == String.Length) return String;
-
-            return String.Substring(OffsetToFirstChar, Length);
+        public string ToString(int maxLength)
+        {
+            return ToString(String, OffsetToFirstChar, maxLength);
         }
 
         public bool Equals(StringRange other)
@@ -62,6 +63,20 @@ namespace AvaloniaEdit.Text
         public static bool operator !=(StringRange left, StringRange right)
         {
             return !left.Equals(right);
+        }
+
+        public StringRange WithLength(int length)
+        {
+            return new StringRange(String, OffsetToFirstChar, length);
+        }
+
+        static string ToString(string value, int offsetToFirstChar, int length)
+        {
+            if (value == null) return string.Empty;
+
+            if (offsetToFirstChar == 0 && length == value.Length) return value;
+
+            return value.Substring(offsetToFirstChar, length);
         }
     }
 }

--- a/src/AvaloniaEdit/Text/TextLineImpl.cs
+++ b/src/AvaloniaEdit/Text/TextLineImpl.cs
@@ -62,6 +62,11 @@ namespace AvaloniaEdit.Text
                 }
 
                 run = TextLineRun.Create(textSource, index, firstIndex, widthLeft, paragraphProperties);
+
+                if (run.Width > widthLeft)
+                {
+                    return new TextLineImpl(paragraphProperties, firstIndex, runs, trailing);
+                }
             }
         }
 

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -104,7 +104,7 @@ namespace AvaloniaEdit.Text
             if (textRun is TextCharacters)
             {
                 return CreateRunForSpecialChars(textSource, stringRange, textRun, index, paragraphProperties) ??
-                       CreateRunForText(stringRange, textRun, widthLeft, false, true, paragraphProperties);
+                       CreateRunForText(stringRange, textRun, widthLeft, paragraphProperties);
             }
 
             if (textRun is TextEndOfLine)
@@ -175,19 +175,35 @@ namespace AvaloniaEdit.Text
             return run;
         }
 
-        internal static TextLineRun CreateRunForText(StringRange stringRange, TextRun textRun, double widthLeft, bool emergencyWrap, bool breakOnTabs, TextParagraphProperties paragraphProperties)
+        internal static TextLineRun CreateRunForText(
+            StringRange stringRange,
+            TextRun textRun,
+            double widthLeft,
+            TextParagraphProperties paragraphProperties)
+        {
+            TextLineRun run = CreateTextLineRun(stringRange, textRun, textRun.Length, paragraphProperties);
+
+            if (run.Width <= widthLeft)
+                return run;
+
+            TextLineRun wrapped = PerformTextWrapping(run, widthLeft, paragraphProperties);
+            wrapped.Width = run.Width;
+            return wrapped;
+        }
+
+        private static TextLineRun CreateTextLineRun(StringRange stringRange, TextRun textRun, int length, TextParagraphProperties paragraphProperties)
         {
             var run = new TextLineRun
             {
                 StringRange = stringRange,
                 TextRun = textRun,
-                Length = textRun.Length
+                Length = length
             };
 
             var tf = run.Typeface;
             var formattedText = new FormattedText
             {
-                Text = stringRange.ToString(),
+                Text = stringRange.ToString(run.Length),
                 Typeface = new Typeface(tf.FontFamily, tf.Style, tf.Weight),
                 FontSize = run.FontSize
             };
@@ -207,6 +223,35 @@ namespace AvaloniaEdit.Text
                 paragraphProperties.DefaultIncrementalTab);
 
             return run;
+        }
+
+        private static TextLineRun PerformTextWrapping(TextLineRun run, double widthLeft, TextParagraphProperties paragraphProperties)
+        {
+            (int firstIndex, int trailingLength) characterHit = run.GetCharacterFromDistance(widthLeft);
+
+            int lenForTextWrapping = GetLenForTextWrapping(run.StringRange, characterHit.firstIndex);
+
+            return CreateTextLineRun(
+                run.StringRange.WithLength(lenForTextWrapping),
+                run.TextRun,
+                lenForTextWrapping,
+                paragraphProperties);
+        }
+
+        private static int GetLenForTextWrapping(StringRange range, int ini)
+        {
+            if (ini > range.Length - 1)
+                ini = range.Length - 1;
+
+            for (int i = ini; i>= 0; i--)
+            {
+                if (range[i] == ' ' || range[i] == '\t')
+                {
+                    return i + 1;
+                }
+            }
+
+            return ini;
         }
 
         private TextLineRun(int length, TextRun textRun)

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -201,8 +201,26 @@ namespace AvaloniaEdit
         private void OnPropertyChangedHandler(object sender, PropertyChangedEventArgs e)
         {
             OnOptionChanged(e);
-
         }
+
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == WordWrapProperty)
+            {
+                if (WordWrap)
+                {
+                    _horizontalScrollBarVisibilityBck = HorizontalScrollBarVisibility;
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+                }
+                else
+                {
+                    HorizontalScrollBarVisibility = _horizontalScrollBarVisibilityBck;
+                }
+            }
+        }
+
         private void OnUndoStackPropertyChangedHandler(object sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == "IsOriginalFile")
@@ -1068,6 +1086,8 @@ namespace AvaloniaEdit
             get => GetValue(HorizontalScrollBarVisibilityProperty);
             set => SetValue(HorizontalScrollBarVisibilityProperty, value);
         }
+
+        private ScrollBarVisibility _horizontalScrollBarVisibilityBck = ScrollBarVisibility.Auto;
 
         /// <summary>
         /// Dependency property for <see cref="VerticalScrollBarVisibility"/>

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/MockFormattedTextImpl.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/MockFormattedTextImpl.cs
@@ -8,11 +8,19 @@ namespace AvaloniaEdit.Tests.AvaloniaMocks
 {
     internal class MockFormattedTextImpl : IFormattedTextImpl
     {
+        private string _text;
+        private Typeface _typeface;
+
+        internal MockFormattedTextImpl(string text, Typeface typeface)
+        {
+            _text = text;
+            _typeface = typeface;
+        }
         Size IFormattedTextImpl.Constraint => new Size(0, 0);
 
-        Rect IFormattedTextImpl.Bounds => new Rect(0, 0, 0, 0);
+        Rect IFormattedTextImpl.Bounds => new Rect(0, 0, _text.Length * _typeface.GlyphTypeface.GetGlyphAdvance(0), 18);
 
-        string IFormattedTextImpl.Text => throw new System.NotImplementedException();
+        string IFormattedTextImpl.Text => _text;
 
         IEnumerable<FormattedTextLine> IFormattedTextImpl.GetLines()
         {

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/MockPlatformRenderInterface.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/MockPlatformRenderInterface.cs
@@ -6,6 +6,8 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Visuals.Media.Imaging;
 
+using AvaloniaEdit.Tests.AvaloniaMocks;
+
 using Moq;
 
 namespace AvaloniaEdit.AvaloniaMocks
@@ -92,7 +94,7 @@ namespace AvaloniaEdit.AvaloniaMocks
 
         public IFormattedTextImpl CreateFormattedText(string text, Typeface typeface, double fontSize, TextAlignment textAlignment, TextWrapping wrapping, Size constraint, IReadOnlyList<FormattedTextStyleSpan> spans)
         {
-            return Mock.Of<IFormattedTextImpl>();
+            return new MockFormattedTextImpl(text, typeface);
         }
 
         public IGeometryImpl CreateGeometryGroup(FillRule fillRule, IReadOnlyList<Geometry> children)

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/TestServices.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/TestServices.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
+using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
@@ -20,14 +21,14 @@ namespace AvaloniaEdit.AvaloniaMocks
     {
         public static readonly TestServices StyledWindow = new TestServices(
             assetLoader: new AssetLoader(),
-            layoutManager: new LayoutManager(null),
             platform: new AppBuilder().RuntimePlatform,
             renderInterface: new MockPlatformRenderInterface(),
             standardCursorFactory: Mock.Of<ICursorFactory>(),
             styler: new Styler(),
             theme: () => CreateDefaultTheme(),
             threadingInterface: Mock.Of<IPlatformThreadingInterface>(x => x.CurrentThreadIsLoopThread == true),
-            windowingPlatform: new MockWindowingPlatform());
+            windowingPlatform: new MockWindowingPlatform(),
+            fontManagerImpl: new MockFontManagerImpl());
 
         public static readonly TestServices MockPlatformRenderInterface = new TestServices(
             renderInterface: new MockPlatformRenderInterface());
@@ -49,9 +50,6 @@ namespace AvaloniaEdit.AvaloniaMocks
             keyboardDevice: () => new KeyboardDevice(),
             keyboardNavigation: new KeyboardNavigationHandler(),
             inputManager: new InputManager());
-
-        public static readonly TestServices RealLayoutManager = new TestServices(
-            layoutManager: new LayoutManager(null));
 
         public static readonly TestServices RealStyler = new TestServices(
             styler: new Styler());

--- a/test/AvaloniaEdit.Tests/Rendering/TextViewTests.cs
+++ b/test/AvaloniaEdit.Tests/Rendering/TextViewTests.cs
@@ -1,0 +1,69 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+using AvaloniaEdit.AvaloniaMocks;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
+using AvaloniaEdit.Text;
+
+using NUnit.Framework;
+
+namespace AvaloniaEdit.Tests.Rendering
+{
+    [TestFixture]
+    internal class TextViewTests
+    {
+        [Test]
+        public void Visual_Line_Should_Create_Two_Text_Lines_When_Wrapping()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            TextView textView = new TextView();
+
+            TextDocument document = new TextDocument("hello world".ToCharArray());
+
+            textView.Document = document;
+            textView.EnsureVisualLines();
+            ((ILogicalScrollable)textView).CanHorizontallyScroll = false;
+            textView.Width = MockGlyphTypeface.GlyphAdvance * 8;
+
+            Window window = new Window();
+            window.Content = textView;
+            window.Show();
+
+            VisualLine visualLine = textView.GetOrConstructVisualLine(document.Lines[0]);
+
+            Assert.AreEqual(2, visualLine.TextLines.Count);
+            Assert.AreEqual("hello ", ((TextLineImpl)visualLine.TextLines[0]).LineRuns[0].StringRange.ToString());
+            Assert.AreEqual("world", ((TextLineImpl)visualLine.TextLines[1]).LineRuns[0].StringRange.ToString());
+
+            window.Close();
+        }
+
+        [Test]
+        public void Visual_Line_Should_Create_One_Text_Lines_When_Not_Wrapping()
+        {
+            using var app = UnitTestApplication.Start(TestServices.StyledWindow);
+
+            TextView textView = new TextView();
+
+            TextDocument document = new TextDocument("hello world".ToCharArray());
+
+            textView.Document = document;
+            textView.EnsureVisualLines();
+            ((ILogicalScrollable)textView).CanHorizontallyScroll = false;
+            textView.Width = MockGlyphTypeface.GlyphAdvance * 500;
+
+            Window window = new Window();
+            window.Content = textView;
+            window.Show();
+
+            VisualLine visualLine = textView.GetOrConstructVisualLine(document.Lines[0]);
+
+            Assert.AreEqual(1, visualLine.TextLines.Count);
+            Assert.AreEqual("hello world", ((TextLineImpl)visualLine.TextLines[0]).LineRuns[0].StringRange.ToString());
+
+            window.Close();
+        }
+    }
+}

--- a/test/AvaloniaEdit.Tests/Text/TextLineImplTests.cs
+++ b/test/AvaloniaEdit.Tests/Text/TextLineImplTests.cs
@@ -99,6 +99,48 @@ namespace AvaloniaEdit.Text
             Assert.IsTrue(textLine.LineRuns[1].IsEnd);
         }
 
+        [Test]
+        public void Text_Line_Should_Not_Wrap_In_Two_Runs_When_Option_Disabled()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "hello world",
+                CreateDefaultTextProperties());
+
+            TextParagraphProperties paraProps = CreateDefaultParagraphProperties();
+            paraProps.TextWrapping = TextWrapping.NoWrap;
+
+            TextLineImpl textLine = TextLineImpl.Create(
+                paraProps, 0, MockGlyphTypeface.GlyphAdvance * 7, s);
+
+            Assert.AreEqual("hello world".Length, textLine.LineRuns[0].Length);
+        }
+
+        [Test]
+        public void Text_Line_Should_Wrap_In_Two_Runs_Option_Enabled()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "hello world",
+                CreateDefaultTextProperties());
+
+            TextParagraphProperties paraProps = CreateDefaultParagraphProperties();
+            paraProps.TextWrapping = TextWrapping.Wrap;
+
+            TextLineImpl textLine = TextLineImpl.Create(
+                paraProps, 0, MockGlyphTypeface.GlyphAdvance * 7, s);
+
+            Assert.AreEqual("hello ".Length, textLine.LineRuns[0].Length);
+        }
+
         TextParagraphProperties CreateDefaultParagraphProperties()
         {
             return new TextParagraphProperties()

--- a/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
+++ b/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
@@ -238,6 +238,80 @@ namespace AvaloniaEdit.Text
             Assert.AreEqual(runHeight, runSize.Height, "Wrong run height");
         }
 
+        [Test]
+        public void Text_Line_Run_Should_Not_Wrap_Line_When_There_Is_Enough_Available_Space()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "0123456789",
+                CreateDefaultTextProperties());
+
+            var paragraphProperties = CreateDefaultParagraphProperties();
+
+            TextLineRun run = TextLineRun.Create(s, 0, 0, 32000, paragraphProperties);
+
+            Assert.AreEqual(10, run.Length);
+        }
+
+        [Test]
+        public void Text_Line_Run_Should_Perform_Word_Wrap_Line_When_Space_Found()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "0123456789 0123456789",
+                CreateDefaultTextProperties());
+
+            var paragraphProperties = CreateDefaultParagraphProperties();
+
+            TextLineRun run = TextLineRun.Create(s, 0, 0, MockGlyphTypeface.GlyphAdvance * 13, paragraphProperties);
+
+            Assert.AreEqual(11, run.Length);
+        }
+
+        [Test]
+        public void Text_Line_Run_Should_Perform_Character_Line_Wrapping_When_Space_Not_Found()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl(),
+                formattedTextImpl: Mock.Of<IFormattedTextImpl>()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "0123456789",
+                CreateDefaultTextProperties());
+
+            var paragraphProperties = CreateDefaultParagraphProperties();
+
+            TextLineRun run = TextLineRun.Create(s, 0, 0, MockGlyphTypeface.GlyphAdvance * 3, paragraphProperties);
+
+            Assert.AreEqual(3, run.Length);
+        }
+
+        [Test]
+        public void Text_Line_Run_Should_Update_StringRange_When_Word_Wrap()
+        {
+            using var app = UnitTestApplication.Start(new TestServices().With(
+                renderInterface: new MockPlatformRenderInterface(),
+                fontManagerImpl: new MockFontManagerImpl()));
+
+            SimpleTextSource s = new SimpleTextSource(
+                "0123456789 0123456789",
+                CreateDefaultTextProperties());
+
+            var paragraphProperties = CreateDefaultParagraphProperties();
+
+            TextLineRun run = TextLineRun.Create(s, 0, 0, MockGlyphTypeface.GlyphAdvance * 13, paragraphProperties);
+
+            Assert.AreEqual("0123456789 ", run.StringRange.ToString());
+        }
+
         TextRunProperties CreateDefaultTextProperties()
         {
             return new TextRunProperties()

--- a/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
+++ b/test/AvaloniaEdit.Tests/Text/TextLineRunTests.cs
@@ -28,7 +28,7 @@ namespace AvaloniaEdit.Text
                 "0123",
                 CreateDefaultTextProperties());
 
-            TextLineRun run = TextLineRun.Create(s, 0, 0, 4, CreateDefaultParagraphProperties());
+            TextLineRun run = TextLineRun.Create(s, 0, 0, 32000, CreateDefaultParagraphProperties());
 
             Assert.AreEqual(MockGlyphTypeface.GlyphAdvance * 0, run.GetDistanceFromCharacter(0));
             Assert.AreEqual(MockGlyphTypeface.GlyphAdvance * 1, run.GetDistanceFromCharacter(1));
@@ -58,8 +58,8 @@ namespace AvaloniaEdit.Text
                 Indent = 4
             };
 
-            TextLineRun run1 = TextLineRun.Create(s1, 0, 0, 2, textParagraphProperties);
-            TextLineRun run2 = TextLineRun.Create(s2, 0, 0, 5, textParagraphProperties);
+            TextLineRun run1 = TextLineRun.Create(s1, 0, 0, 32000, textParagraphProperties);
+            TextLineRun run2 = TextLineRun.Create(s2, 0, 0, 32000, textParagraphProperties);
 
             Assert.AreEqual(
                 run1.GetDistanceFromCharacter(1),
@@ -99,7 +99,7 @@ namespace AvaloniaEdit.Text
 
             var paragraphProperties = CreateDefaultParagraphProperties();
 
-            TextLineRun run = TextLineRun.Create(s, 0, 0, 1, paragraphProperties);
+            TextLineRun run = TextLineRun.Create(s, 0, 0, 32000, paragraphProperties);
 
             double[] expectedLengths = new double[]
             {
@@ -127,7 +127,7 @@ namespace AvaloniaEdit.Text
 
             var paragraphProperties = CreateDefaultParagraphProperties();
 
-            TextLineRun run = TextLineRun.Create(s, 0, 0, 1, paragraphProperties);
+            TextLineRun run = TextLineRun.Create(s, 0, 0, 32000, paragraphProperties);
 
             double[] expectedLengths = new double[]
             {


### PR DESCRIPTION
Fixes #205.

Sometime this year we will change AvaloniaEdit text API to use Avalonia's TextFormatter API. In the meantime, I fixed the existing codebase. This PR fixes and extends the existing word-wrap implementation:

- Fixed the `TextLineImpl `to not add a run that doesn't fit the `widthLeft`.
- Added support for word wrapping in the `TextLineRun`.
- Automatically disable the horizontal scroll when setting `WordWrap=True`

Some demo.

https://user-images.githubusercontent.com/501613/153749514-2450e042-1b5b-4934-a3d4-aeb4f00090dd.mp4




