### PR TITLE
Fix NRE in TM language extensions

### DIFF
--- a/src/AvaloniaEdit.TextMate.Grammars/RegistryOptions.cs
+++ b/src/AvaloniaEdit.TextMate.Grammars/RegistryOptions.cs
@@ -72,6 +72,9 @@ namespace AvaloniaEdit.TextMate.Grammars
             {
                 foreach (var language in definition.Contributes.Languages)
                 {
+                    if (language.Extensions == null)
+                        continue;
+
                     foreach (var languageExtension in language.Extensions)
                     {
                         if (extension.Equals(languageExtension,


### PR DESCRIPTION
Some TM languages don't define language.Extensions, protect it.