### PR TITLE
Fixed index out of range replacing text

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AvaloniaVersion>0.10.12</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.29</TextMateSharpVersion>
+    <TextMateSharpVersion>1.0.31</TextMateSharpVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
 	<Version>0.10.12.2</Version>
   </PropertyGroup>

--- a/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
+++ b/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 using AvaloniaEdit.Document;
 
@@ -15,7 +17,6 @@ namespace AvaloniaEdit.TextMate
         public int LineCount
         {
             get { lock (_lock) { return _lineCount; } }
-            set { lock (_lock) { _lineCount = value; } }
         }
 
         public DocumentSnapshot(TextDocument document)
@@ -24,6 +25,17 @@ namespace AvaloniaEdit.TextMate
             _lineRanges = new LineRange[document.LineCount];
 
             Update(null);
+        }
+
+        public void RemoveLines(int startLine, int endLine)
+        {
+            lock (_lock)
+            {
+                var tmpList = _lineRanges.ToList();
+                tmpList.RemoveRange(startLine, endLine - startLine + 1);
+                _lineRanges = tmpList.ToArray();
+                _lineCount = _lineRanges.Length;
+            }
         }
 
         public string GetLineText(int lineIndex)

--- a/src/AvaloniaEdit.TextMate/TextEditorModel.cs
+++ b/src/AvaloniaEdit.TextMate/TextEditorModel.cs
@@ -93,8 +93,9 @@ namespace AvaloniaEdit.TextMate
                     for (int i = endLine; i > startLine; i--)
                     {
                         RemoveLine(i);
-                        _documentSnapshot.LineCount--;
                     }
+
+                    _documentSnapshot.RemoveLines(startLine, endLine);
                 }
             }
             catch (Exception ex)

--- a/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
+++ b/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
@@ -85,5 +85,57 @@ namespace AvaloniaEdit.Tests.TextMate
             Assert.AreEqual(7, documentSnaphot.GetTotalLineLength(1));
             Assert.AreEqual(6, documentSnaphot.GetTotalLineLength(2));
         }
+
+        [Test]
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_All_Lines()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot documentSnaphot = new DocumentSnapshot(document);
+
+            documentSnaphot.RemoveLines(0, 3);
+
+            Assert.AreEqual(0, documentSnaphot.LineCount);
+        }
+
+        [Test]
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_First_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot documentSnaphot = new DocumentSnapshot(document);
+
+            documentSnaphot.RemoveLines(0, 0);
+
+            Assert.AreEqual(3, documentSnaphot.LineCount);
+        }
+
+        [Test]
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_Two_First_Lines()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot documentSnaphot = new DocumentSnapshot(document);
+
+            documentSnaphot.RemoveLines(0, 1);
+
+            Assert.AreEqual(2, documentSnaphot.LineCount);
+        }
+
+        [Test]
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_Last_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot documentSnaphot = new DocumentSnapshot(document);
+
+            documentSnaphot.RemoveLines(3, 3);
+
+            Assert.AreEqual(3, documentSnaphot.LineCount);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an `IndexOutOfRangeException` when replacing text in the Editor using the following shortcut keys:

- Copy text to the clipboard from another text source.
- Go back to AvaloniaEdit.
- Select <kbd>Ctrl + A</kbd> to select all text.
- Hit <kbd>Ctrl + V</kbd> to paste that text.

In the time-lapse between the events `DocumentOnChanging` and `DocumentOnChanged`, the TMModel still asked for old lines with old LineRanges (offset + len) which caused AvaloniaEdit to fail when getting the text from the rope.

Now it's fixed.