### PR TITLE
fix the wrong complete window position

### DIFF
--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
@@ -76,15 +76,20 @@ namespace AvaloniaEdit.CodeCompletion
         /// Creates a new CompletionWindowBase.
         /// </summary>
         public CompletionWindowBase(TextArea textArea) : base()
-        {     
+        {
             TextArea = textArea ?? throw new ArgumentNullException(nameof(textArea));
             _parentWindow = textArea.GetVisualRoot() as Window;
 
-           
+
             AddHandler(PointerReleasedEvent, OnMouseUp, handledEventsToo: true);
 
             StartOffset = EndOffset = TextArea.Caret.Offset;
-            
+
+            PlacementTarget = TextArea.TextView;
+            PlacementMode = PlacementMode.AnchorAndGravity;
+            PlacementAnchor = Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor.TopLeft;
+            PlacementGravity = Avalonia.Controls.Primitives.PopupPositioning.PopupGravity.BottomRight;
+
             //Deactivated += OnDeactivated; //Not needed?
 
             Closed += (sender, args) => DetachEvents();
@@ -113,11 +118,11 @@ namespace AvaloniaEdit.CodeCompletion
 
         public void Show()
         {
+            UpdatePosition();
+
             Open();
             Height = double.NaN;
             MinHeight = 0;
-
-            UpdatePosition();
         }
 
         public void Hide()
@@ -206,7 +211,7 @@ namespace AvaloniaEdit.CodeCompletion
                 base.Detach();
                 Window.Hide();
             }
-            
+
             public override void OnPreviewKeyDown(KeyEventArgs e)
             {
                 // prevents crash when typing deadchar while CC window is open
@@ -372,7 +377,8 @@ namespace AvaloniaEdit.CodeCompletion
 
             var position = _visualLocation - textView.ScrollOffset;
 
-            Host?.ConfigurePosition(textView, PlacementMode.AnchorAndGravity, position, Avalonia.Controls.Primitives.PopupPositioning.PopupAnchor.TopLeft, Avalonia.Controls.Primitives.PopupPositioning.PopupGravity.BottomRight);
+            this.HorizontalOffset = position.X;
+            this.VerticalOffset = position.Y;
         }
 
         // TODO: check if needed


### PR DESCRIPTION
about https://github.com/AvaloniaUI/AvaloniaEdit/issues/194.

In Avalonia 0.10.11, Avalonia [observes the position of the popup parent](https://github.com/AvaloniaUI/Avalonia/blob/089fda0dc7fedd67ed6a4febd2be8c843760eb55/src/Avalonia.Controls/Primitives/Popup.cs#L430), and moves popup accordingly.

Currently, `CompletionWindowBase` dosen't change `PlacementTarget`. This causes that the position of the popup parent is treated as a position of the popup ([L380](https://github.com/AvaloniaUI/Avalonia/blob/089fda0dc7fedd67ed6a4febd2be8c843760eb55/src/Avalonia.Controls/Primitives/Popup.cs#L380) and [L388](https://github.com/AvaloniaUI/Avalonia/blob/089fda0dc7fedd67ed6a4febd2be8c843760eb55/src/Avalonia.Controls/Primitives/Popup.cs#L388)).
So [Host.ComfigurePosition](https://github.com/whistyun/AvaloniaEdit/blob/7a7c8990db326b0a89611d777eb7b6e84403101c/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs#L375) is treated as changing the position of the popup parent.
As a result, The position of the popup is re-moved to `(HorizontalOffset`, `VerticalOffset`).

This PR fixes the problem by changing properties affect the position of the popup.
