### PR TITLE
Expose the search panel in the TextEditor

### DIFF
--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -484,6 +484,11 @@ namespace AvaloniaEdit.Search
         public bool IsClosed { get; private set; }
 
         /// <summary>
+        /// Gets whether the Panel is currently opened.
+        /// </summary>
+        public bool IsOpened => !IsClosed;
+
+        /// <summary>
         /// Closes the SearchPanel.
         /// </summary>
         public void Close()

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -32,6 +32,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Data;
 using AvaloniaEdit.Search;
@@ -283,6 +284,7 @@ namespace AvaloniaEdit
         #region TextArea / ScrollViewer properties
         private readonly TextArea textArea;
         private SearchPanel searchPanel;
+        private bool wasSearchPanelOpened;
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
@@ -291,6 +293,27 @@ namespace AvaloniaEdit
             ScrollViewer.Content = TextArea;
 
             searchPanel = SearchPanel.Install(this);
+        }
+
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToLogicalTree(e);
+
+            if (searchPanel != null && wasSearchPanelOpened)
+            {
+                searchPanel.Open();
+            }
+        }
+
+        protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromLogicalTree(e);
+
+            if (searchPanel != null)
+            {
+                wasSearchPanelOpened = !searchPanel.IsClosed;
+                searchPanel.Close();
+            }
         }
 
         /// <summary>

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -282,20 +282,26 @@ namespace AvaloniaEdit
 
         #region TextArea / ScrollViewer properties
         private readonly TextArea textArea;
-        
+        private SearchPanel searchPanel;
+
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
             ScrollViewer = (ScrollViewer)e.NameScope.Find("PART_ScrollViewer");
             ScrollViewer.Content = TextArea;
 
-            SearchPanel.Install(this);
+            searchPanel = SearchPanel.Install(this);
         }
 
         /// <summary>
         /// Gets the text area.
         /// </summary>
         public TextArea TextArea => textArea;
+
+        /// <summary>
+        /// Gets the search panel.
+        /// </summary>
+        public SearchPanel SearchPanel => searchPanel;
 
         /// <summary>
         /// Gets the scroll viewer used by the text editor.

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -311,8 +311,9 @@ namespace AvaloniaEdit
 
             if (searchPanel != null)
             {
-                wasSearchPanelOpened = !searchPanel.IsClosed;
-                searchPanel.Close();
+                wasSearchPanelOpened = searchPanel.IsOpened;
+                if (searchPanel.IsOpened)
+                    searchPanel.Close();
             }
         }
 


### PR DESCRIPTION
Expose the `SearchPanel` in the `TextEditor` so users can, manage the search panel programmatically (for example, show, hide, change the search term, etc ...).

Additionally, fixed an issue with the search panel control template. When the search panel was visible, and then you detached the `TextEditor` from the logical tree, and you attached it later (i.e moving the control from one panel to another), the SearchPanel's control template was lost. I fixed it by closing the SearchPanel when detaching from the logical tree and restoring it if needed when attaching.