### PR TITLE
Update Textmatesharp to 1.0.34

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AvaloniaVersion>0.10.12</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.31</TextMateSharpVersion>
+    <TextMateSharpVersion>1.0.34</TextMateSharpVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
 	<Version>0.10.12.2</Version>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <AvaloniaVersion>0.10.12</AvaloniaVersion>
     <TextMateSharpVersion>1.0.34</TextMateSharpVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-	<Version>0.10.12.2</Version>
+    <Version>0.10.12.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This new version includes:

- Fixes Operations that change non-concurrent collections must have exclusive access: https://github.com/danipen/TextMateSharp/pull/16
- Use .net 6.0 for building the nugets: https://github.com/danipen/TextMateSharp/pull/17