### PR TITLE
Update to TextMateSharp 1.0.38

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AvaloniaVersion>0.10.12</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.34</TextMateSharpVersion>
+    <TextMateSharpVersion>1.0.38</TextMateSharpVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <Version>0.10.12.2</Version>
   </PropertyGroup>


### PR DESCRIPTION
Enables TextMateSharp x86 architecture.