### PR TITLE
Expose properties for context menus

### DIFF
--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -76,6 +76,7 @@ namespace AvaloniaEdit.Editing
             AddBinding(EditingCommands.TabForward, KeyModifiers.None, Key.Tab, OnTab);
             AddBinding(EditingCommands.TabBackward, KeyModifiers.Shift, Key.Tab, OnShiftTab);
 
+            AddBinding(ApplicationCommands.Delete, OnDelete(CaretMovementType.None), CanDelete);
             AddBinding(ApplicationCommands.Copy, OnCopy, CanCutOrCopy);
             AddBinding(ApplicationCommands.Cut, OnCut, CanCutOrCopy);
             AddBinding(ApplicationCommands.Paste, OnPaste, CanPaste);

--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -77,8 +77,8 @@ namespace AvaloniaEdit.Editing
             AddBinding(EditingCommands.TabBackward, KeyModifiers.Shift, Key.Tab, OnShiftTab);
 
             AddBinding(ApplicationCommands.Delete, OnDelete(CaretMovementType.None), CanDelete);
-            AddBinding(ApplicationCommands.Copy, OnCopy, CanCutOrCopy);
-            AddBinding(ApplicationCommands.Cut, OnCut, CanCutOrCopy);
+            AddBinding(ApplicationCommands.Copy, OnCopy, CanCopy);
+            AddBinding(ApplicationCommands.Cut, OnCut, CanCut);
             AddBinding(ApplicationCommands.Paste, OnPaste, CanPaste);
 
             AddBinding(AvaloniaEditCommands.ToggleOverstrike, OnToggleOverstrike);
@@ -342,7 +342,18 @@ namespace AvaloniaEdit.Editing
 
         #region Clipboard commands
 
-        private static void CanCutOrCopy(object target, CanExecuteRoutedEventArgs args)
+        private static void CanCut(object target, CanExecuteRoutedEventArgs args)
+        {
+            // HasSomethingSelected for copy and cut commands
+            var textArea = GetTextArea(target);
+            if (textArea?.Document != null)
+            {
+                args.CanExecute = (textArea.Options.CutCopyWholeLine || !textArea.Selection.IsEmpty) && !textArea.IsReadOnly;
+                args.Handled = true;
+            }
+        }
+
+        private static void CanCopy(object target, CanExecuteRoutedEventArgs args)
         {
             // HasSomethingSelected for copy and cut commands
             var textArea = GetTextArea(target);

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -250,6 +250,14 @@ namespace AvaloniaEdit.Editing
         /// <inheritdoc/>
         public event EventHandler DocumentChanged;
 
+        /// <summary>
+        /// Gets if the the document displayed by the text editor is readonly
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get => ReadOnlySectionProvider == ReadOnlySectionDocument.Instance;
+        }
+
         private static void OnDocumentChanged(AvaloniaPropertyChangedEventArgs e)
         {
             (e.Sender as TextArea)?.OnDocumentChanged((TextDocument)e.OldValue, (TextDocument)e.NewValue);

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -587,7 +587,7 @@ namespace AvaloniaEdit
         /// </summary>
         public void Copy()
         {
-            if (ApplicationCommands.Copy.CanExecute(null, TextArea))
+            if (CanCopy)
             {
                 ApplicationCommands.Copy.Execute(null, TextArea);
             }
@@ -598,7 +598,7 @@ namespace AvaloniaEdit
         /// </summary>
         public void Cut()
         {
-            if (ApplicationCommands.Cut.CanExecute(null, TextArea))
+            if (CanCut)
             {
                 ApplicationCommands.Cut.Execute(null, TextArea);
             }
@@ -618,7 +618,7 @@ namespace AvaloniaEdit
         /// </summary>
         public void Delete()
         {
-            if(ApplicationCommands.Delete.CanExecute(null, TextArea))
+            if(CanDelete)
             {
                 ApplicationCommands.Delete.Execute(null, TextArea);
             }
@@ -709,7 +709,7 @@ namespace AvaloniaEdit
         /// </summary>
         public void Paste()
         {
-            if (ApplicationCommands.Paste.CanExecute(null, TextArea))
+            if (CanPaste)
             {
                 ApplicationCommands.Paste.Execute(null, TextArea);
             }
@@ -772,7 +772,7 @@ namespace AvaloniaEdit
         /// </summary>
         public void SelectAll()
         {
-            if (ApplicationCommands.SelectAll.CanExecute(null, TextArea))
+            if (CanSelectAll)
             {
                 ApplicationCommands.SelectAll.Execute(null, TextArea);
             }
@@ -806,6 +806,54 @@ namespace AvaloniaEdit
         public bool CanUndo
         {
             get { return ApplicationCommands.Undo.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if text in editor can be copied
+        /// </summary>
+        public bool CanCopy
+        {
+            get { return ApplicationCommands.Copy.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if text in editor can be cut
+        /// </summary>
+        public bool CanCut
+        {
+            get { return ApplicationCommands.Cut.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if text in editor can be pasted
+        /// </summary>
+        public bool CanPaste
+        {
+            get { return ApplicationCommands.Paste.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if selected text in editor can be deleted
+        /// </summary>
+        public bool CanDelete
+        {
+            get { return ApplicationCommands.Delete.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if text the editor can select all
+        /// </summary>
+        public bool CanSelectAll
+        {
+            get { return ApplicationCommands.SelectAll.CanExecute(null, TextArea); }
+        }
+
+        /// <summary>
+        /// Gets if text editor can activate the search panel
+        /// </summary>
+        public bool CanSearch
+        {
+            get { return searchPanel != null; }
         }
 
         /// <summary>


### PR DESCRIPTION
Expose some properties like:

- CanCopy
- CanCut
- CanPaste
- CanDelete
- CanSelectAll
- CanSearch

to be queried so any implementation for a ContextMenu for an editor can query these properties to set up the menu item enablement.