### PR TITLE
Fix strikethrough in macOS

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -247,7 +247,6 @@ namespace AvaloniaEdit.Demo
         {
             protected override void ColorizeLine(DocumentLine line)
             {
-                
                 if (line.LineNumber == 2)
                 {
                     string lineText = this.CurrentContext.Document.GetText(line);

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -92,7 +92,7 @@ namespace AvaloniaEdit.Demo
                 "// AvaloniaEdit supports displaying underline and strikethrough" + Environment.NewLine +
                 ResourceLoader.LoadSampleFile(scopeName));
             _textMateInstallation.SetGrammar(_registryOptions.GetScopeByLanguageId(csharpLanguage.Id));
-            _textEditor.TextArea.TextView.LineTransformers.Add(new CustomFormatTransformer());
+            _textEditor.TextArea.TextView.LineTransformers.Add(new UnderlineAndStrikeThroughTransformer());
 
             _statusTextBlock = this.Find<TextBlock>("StatusText");
 
@@ -120,13 +120,7 @@ namespace AvaloniaEdit.Demo
 
         private void SyntaxModeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            for (int i = _textEditor.TextArea.TextView.LineTransformers.Count - 1; i >= 0; i--)
-            {
-                if (_textEditor.TextArea.TextView.LineTransformers[i] is CustomFormatTransformer)
-                {
-                    _textEditor.TextArea.TextView.LineTransformers.RemoveAt(i);
-                }
-            }
+            RemoveUnderlineAndStrikethroughTransformer();
 
             Language language = (Language)_syntaxModeCombo.SelectedItem;
 
@@ -149,6 +143,17 @@ namespace AvaloniaEdit.Demo
                 var strategy = new XmlFoldingStrategy();
                 strategy.UpdateFoldings(_foldingManager, _textEditor.Document);
                 return;
+            }
+        }
+
+        private void RemoveUnderlineAndStrikethroughTransformer()
+        {
+            for (int i = _textEditor.TextArea.TextView.LineTransformers.Count - 1; i >= 0; i--)
+            {
+                if (_textEditor.TextArea.TextView.LineTransformers[i] is UnderlineAndStrikeThroughTransformer)
+                {
+                    _textEditor.TextArea.TextView.LineTransformers.RemoveAt(i);
+                }
             }
         }
 
@@ -238,7 +243,7 @@ namespace AvaloniaEdit.Demo
             }
         }
 
-        class CustomFormatTransformer : DocumentColorizingTransformer
+        class UnderlineAndStrikeThroughTransformer : DocumentColorizingTransformer
         {
             protected override void ColorizeLine(DocumentLine line)
             {

--- a/src/AvaloniaEdit/Text/TextLineRun.cs
+++ b/src/AvaloniaEdit/Text/TextLineRun.cs
@@ -311,9 +311,15 @@ namespace AvaloniaEdit.Text
 
                 if (TextRun.Properties.Strikethrough)
                 {
-                    var pen = new Pen(TextRun.Properties.ForegroundBrush, glyphTypeface.StrikethroughThickness * scale);
+                    double penThickness = glyphTypeface.StrikethroughThickness == 0 ?
+                        0.5 :
+                        glyphTypeface.StrikethroughThickness * scale;
 
-                    var posY = baseline + glyphTypeface.StrikethroughPosition * scale;
+                    var pen = new Pen(TextRun.Properties.ForegroundBrush, penThickness);
+
+                    var posY = glyphTypeface.StrikethroughPosition == 0
+                        ? glyphTypeface.LineHeight * scale / 2
+                        : baseline + glyphTypeface.StrikethroughPosition * scale;
 
                     drawingContext.DrawLine(pen,
                         new Point(x, posY),


### PR DESCRIPTION
Strikethrough lines are not displayed in macOS.

The reason is that the glyphTypeface's `StrikethroughThickness `and `StrikethroughPosition ` in macOS are 0 (**note that this is working ok in Windows OS**).

This PR also adds some underline and strikethrough sample text to the sample application.