### PR TITLE
Align the selection rectangle top position with the caret top position

### DIFF
--- a/src/AvaloniaEdit/Rendering/BackgroundGeometryBuilder.cs
+++ b/src/AvaloniaEdit/Rendering/BackgroundGeometryBuilder.cs
@@ -196,7 +196,7 @@ namespace AvaloniaEdit.Rendering
 
 			for (int i = 0; i < visualLine.TextLines.Count; i++) {
 				TextLine line = visualLine.TextLines[i];
-				double y = visualLine.GetTextLineVisualYPosition(line, VisualYPosition.LineTop);
+				double y = visualLine.GetTextLineVisualYPosition(line, VisualYPosition.TextTop);
 				int visualStartCol = visualLine.GetTextLineVisualStartColumn(line);
 				int visualEndCol = visualStartCol + line.Length;
 				if (line == lastTextLine)


### PR DESCRIPTION
This PR aligns the position of the selection with the position of the caret. 

The `Caret` is using the `VisualYPosition.TextTop` to calculate the position. So also use that method to calculate the `VisualYPosition` for a line when calculating the `y` position of the selection rectangle.