### PR TITLE
Try building without the System.Xml.ReaderWriter nuget package reference

### DIFF
--- a/src/AvaloniaEdit/AvaloniaEdit.csproj
+++ b/src/AvaloniaEdit/AvaloniaEdit.csproj
@@ -35,7 +35,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
-    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

I was doing some tests with AvaloniaEdit and Avalonia.FuncUI and wondered if the System.Xml.ReaderWriter nuget package reference is needed when targetting netstandard2.0 (System.Xml being built in to that version).

(Reasoning: the security tools at work like to complain about indirect references to old versions of System.Text.RegularExpressions that have security vulnerabilities and I got in a habbit of removing old references if they don't seem to be required any more)