### PR TITLE
Fix allow scroll below document

### DIFF
--- a/src/AvaloniaEdit/Editing/Caret.cs
+++ b/src/AvaloniaEdit/Editing/Caret.cs
@@ -452,14 +452,14 @@ namespace AvaloniaEdit.Editing
         /// <summary>
         /// Minimum distance of the caret to the view border.
         /// </summary>
-        internal const double MinimumDistanceToViewBorder = 30;
+        internal const double MinimumDistanceToViewBorder = 0;
 
         /// <summary>
         /// Scrolls the text view so that the caret is visible.
         /// </summary>
         public void BringCaretToView()
         {
-            BringCaretToView(MinimumDistanceToViewBorder);
+            BringCaretToView(0);
         }
 
         public void BringCaretToView(double border)

--- a/src/AvaloniaEdit/Editing/LineNumberMargin.cs
+++ b/src/AvaloniaEdit/Editing/LineNumberMargin.cs
@@ -177,7 +177,7 @@ namespace AvaloniaEdit.Editing
                     {
                         ExtendSelection(currentSeg);
                     }
-                    TextArea.Caret.BringCaretToView(5.0);
+                    TextArea.Caret.BringCaretToView(0);
                 }
             }
         }
@@ -223,7 +223,7 @@ namespace AvaloniaEdit.Editing
                 if (currentSeg == SimpleSegment.Invalid)
                     return;
                 ExtendSelection(currentSeg);
-                TextArea.Caret.BringCaretToView(5.0);
+                TextArea.Caret.BringCaretToView(0);
             }
             base.OnPointerMoved(e);
         }

--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -704,7 +704,7 @@ namespace AvaloniaEdit.Editing
                     TextArea.Caret.Offset = newWord.Offset < _startWord.Offset ? newWord.Offset : Math.Max(newWord.EndOffset, _startWord.EndOffset);
                 }
             }
-            TextArea.Caret.BringCaretToView(5.0);
+            TextArea.Caret.BringCaretToView(0);
         }
         #endregion
 

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -872,7 +872,7 @@ namespace AvaloniaEdit.Rendering
 			foreach (var layer in Layers) {
 				layer.Measure(availableSize);
 			}
-			
+
             MeasureInlineObjects();
 
             double maxWidth;
@@ -902,6 +902,8 @@ namespace AvaloniaEdit.Rendering
             maxWidth += AdditionalHorizontalScrollAmount;
             var heightTreeHeight = DocumentHeight;
             var options = Options;
+            double desiredHeight = Math.Min(availableSize.Height, heightTreeHeight);
+            double extraHeightToAllowScrollBelowDocument = 0;
             if (options.AllowScrollBelowDocument)
             {
                 if (!double.IsInfinity(_scrollViewport.Height))
@@ -909,22 +911,20 @@ namespace AvaloniaEdit.Rendering
                     // HACK: we need to keep at least Caret.MinimumDistanceToViewBorder visible so that we don't scroll back up when the user types after
                     // scrolling to the very bottom.
                     var minVisibleDocumentHeight = Math.Max(DefaultLineHeight, Caret.MinimumDistanceToViewBorder);
-                    // scrollViewportBottom: bottom of scroll view port, but clamped so that at least minVisibleDocumentHeight of the document stays visible.
-                    var scrollViewportBottom = Math.Min(heightTreeHeight - minVisibleDocumentHeight, _scrollOffset.Y) + _scrollViewport.Height;
                     // increase the extend height to allow scrolling below the document
-                    heightTreeHeight = Math.Max(heightTreeHeight, scrollViewportBottom);
+                    extraHeightToAllowScrollBelowDocument = desiredHeight - minVisibleDocumentHeight;
                 }
             }
 
             TextLayer.SetVisualLines(_visibleVisualLines);
 
             SetScrollData(availableSize,
-                          new Size(maxWidth, heightTreeHeight),
+                          new Size(maxWidth, heightTreeHeight + extraHeightToAllowScrollBelowDocument),
                           _scrollOffset);
 
             VisualLinesChanged?.Invoke(this, EventArgs.Empty);
 
-            return new Size(Math.Min(availableSize.Width, maxWidth), Math.Min(availableSize.Height, heightTreeHeight));
+            return new Size(Math.Min(availableSize.Width, maxWidth), desiredHeight);
         }
 
 		/// <summary>

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -873,8 +873,6 @@ namespace AvaloniaEdit.Rendering
 				layer.Measure(availableSize);
 			}
 			
-			//InvalidateVisual(); // = InvalidateArrange+InvalidateRender
-
             MeasureInlineObjects();
 
             double maxWidth;
@@ -923,9 +921,6 @@ namespace AvaloniaEdit.Rendering
             SetScrollData(availableSize,
                           new Size(maxWidth, heightTreeHeight),
                           _scrollOffset);
-
-            // Size of control (scorll viewport) might be changed during ArrageOverride. We only need document size for now.
-            _documentSize = new Size(maxWidth, heightTreeHeight);
 
             VisualLinesChanged?.Invoke(this, EventArgs.Empty);
 
@@ -1152,13 +1147,13 @@ namespace AvaloniaEdit.Rendering
             // validate scroll position
             var newScrollOffsetX = _scrollOffset.X;
             var newScrollOffsetY = _scrollOffset.Y;
-            if (_scrollOffset.X + finalSize.Width > _documentSize.Width)
+            if (_scrollOffset.X + finalSize.Width > _scrollExtent.Width)
             {
-                newScrollOffsetX = Math.Max(0, _documentSize.Width - finalSize.Width);
+                newScrollOffsetX = Math.Max(0, _scrollExtent.Width - finalSize.Width);
             }
-            if (_scrollOffset.Y + finalSize.Height > _documentSize.Height)
+            if (_scrollOffset.Y + finalSize.Height > _scrollExtent.Height)
             {
-                newScrollOffsetY = Math.Max(0, _documentSize.Height - finalSize.Height);
+                newScrollOffsetY = Math.Max(0, _scrollExtent.Height - finalSize.Height);
             }
 
             // Apply final view port and offset
@@ -1316,11 +1311,6 @@ namespace AvaloniaEdit.Rendering
         /// Size of the scroll, in pixels.
         /// </summary>
         private Size _scrollExtent;
-
-        /// <summary>
-        /// Size of the document, in pixels.
-        /// </summary>
-        private Size _documentSize;
 
         /// <summary>
         /// Offset of the scroll position.
@@ -2052,7 +2042,7 @@ namespace AvaloniaEdit.Rendering
             }
         }
 
-        bool ILogicalScrollable.IsLogicalScrollEnabled => true;        
+        bool ILogicalScrollable.IsLogicalScrollEnabled => true;
 
         Size ILogicalScrollable.ScrollSize => new Size(10, 50);
 

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -116,7 +116,17 @@ namespace AvaloniaEdit.Rendering
             set => SetValue(DocumentProperty, value);
         }
 
-        internal double FontSize => GetValue(TextBlock.FontSizeProperty);
+        internal double FontSize
+        {
+            get => GetValue(TemplatedControl.FontSizeProperty);
+            set => SetValue(TemplatedControl.FontSizeProperty, value);
+        }
+
+        internal FontFamily FontFamily
+        {
+            get => GetValue(TemplatedControl.FontFamilyProperty);
+            set => SetValue(TemplatedControl.FontFamilyProperty, value);
+        }
 
         /// <summary>
         /// Occurs when the document property has changed.
@@ -910,7 +920,7 @@ namespace AvaloniaEdit.Rendering
                 {
                     // HACK: we need to keep at least Caret.MinimumDistanceToViewBorder visible so that we don't scroll back up when the user types after
                     // scrolling to the very bottom.
-                    var minVisibleDocumentHeight = Math.Max(DefaultLineHeight, Caret.MinimumDistanceToViewBorder);
+                    var minVisibleDocumentHeight = DefaultLineHeight;
                     // increase the extend height to allow scrolling below the document
                     extraHeightToAllowScrollBelowDocument = desiredHeight - minVisibleDocumentHeight;
                 }

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -59,6 +59,8 @@ namespace AvaloniaEdit
             IsModifiedProperty.Changed.Subscribe(OnIsModifiedChanged);
             ShowLineNumbersProperty.Changed.Subscribe(OnShowLineNumbersChanged);
             LineNumbersForegroundProperty.Changed.Subscribe(OnLineNumbersForegroundChanged);
+            FontFamilyProperty.Changed.Subscribe(OnFontFamilyPropertyChanged);
+            FontSizeProperty.Changed.Subscribe(OnFontSizePropertyChanged);
         }
 
         /// <summary>
@@ -562,6 +564,21 @@ namespace AvaloniaEdit
 
             lineNumberMargin?.SetValue(ForegroundProperty, e.NewValue);
         }
+
+        private static void OnFontFamilyPropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var editor = e.Sender as TextEditor;
+
+            editor?.TextArea.TextView.SetValue(FontFamilyProperty, e.NewValue);
+        }
+
+        private static void OnFontSizePropertyChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            var editor = e.Sender as TextEditor;
+
+            editor?.TextArea.TextView.SetValue(FontSizeProperty, e.NewValue);
+        }
+
         #endregion
 
         #region TextBoxBase-like methods


### PR DESCRIPTION

This PR fixes the `AllowScrollBelowDocument` option. The event chain in the ScrollViewer prevented AvaloniaEdit to reserve more space for the viewport, because when the scrollbar reached the max viewport no new events sent, so the code did not work as WPF.

After these fixes, when the option `AllowScrollBelowDocument` is enabled, the TextView adds an extra height of `Bounds.Height - DefaultLineHeight` so the user is able to scroll. We ensure that at least one line is visible.

I also removed the margins used when the TextEditor is clicked, or the line is being edited. It used a margin of 5px for mouse clicks and a 30px margin when editing text. This helps to maintain the scroll more stable when editing or clicking the textView in the edges.

Some demo:

https://user-images.githubusercontent.com/501613/190992676-3036c810-54e9-46df-92e1-6e8ccfdc0c3e.mp4



Fixes #141.