### PR TITLE
Add an option to avoid extend selection on mouse up

### DIFF
--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -726,7 +726,8 @@ namespace AvaloniaEdit.Editing
                 case SelectionMode.WholeWord:
                 case SelectionMode.WholeLine:
                 case SelectionMode.Rectangular:
-                    ExtendSelectionToMouse(e);
+                    if (TextArea.Options.ExtendSelectionOnMouseUp)
+                        ExtendSelectionToMouse(e);
                     break;
             }
             _mode = SelectionMode.None;

--- a/src/AvaloniaEdit/TextEditorOptions.cs
+++ b/src/AvaloniaEdit/TextEditorOptions.cs
@@ -558,5 +558,24 @@ namespace AvaloniaEdit
                 }
             }
         }
+
+        private bool _extendSelectionOnMouseUp = true;
+
+        /// <summary>
+        /// Gets/Sets if the mouse up event should extend the editor selection to the mouse position.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool ExtendSelectionOnMouseUp
+        {
+            get { return _extendSelectionOnMouseUp; }
+            set
+            {
+                if (_extendSelectionOnMouseUp != value)
+                {
+                    _extendSelectionOnMouseUp = value;
+                    OnPropertyChanged("ExtendSelectionOnMouseUp");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is useful when the textbox adds some scroll animations on pointer down, which causes unwanted selections when the mouse button is released.

Note that Visual Studio (and Visual Studio Code) don't update the selection on mouse up, so the option makes sense.