### PR TITLE
Make control characters configurable

### DIFF
--- a/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
@@ -210,7 +210,7 @@ namespace AvaloniaEdit.Rendering
 			}
 		}
 
-		public sealed class SpecialCharacterBoxElement : FormattedTextElement
+		private sealed class SpecialCharacterBoxElement : FormattedTextElement
 		{
 			public SpecialCharacterBoxElement(TextLine text) : base(text, 1)
 			{

--- a/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
@@ -99,27 +99,41 @@ namespace AvaloniaEdit.Rendering
 			return -1;
 		}
 
-		public override VisualLineElement ConstructElement(int offset)
-		{
-			var c = CurrentContext.Document.GetCharAt(offset);
+        public override VisualLineElement ConstructElement(int offset)
+        {
+            var c = CurrentContext.Document.GetCharAt(offset);
 
-			if (ShowSpaces && c == ' ') {
-				return new SpaceTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter("\u00B7", CurrentContext));
-			} else if (ShowTabs && c == '\t') {
-				return new TabTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter("\u00BB", CurrentContext));
-			} else if (ShowBoxForControlCharacters && char.IsControl(c)) {
-				var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-				p.SetForegroundBrush(Brushes.White);
-				var textFormatter = TextFormatterFactory.Create(CurrentContext.TextView);
-				var text = FormattedTextElement.PrepareText(textFormatter,
-															TextUtilities.GetControlCharacterName(c), p);
-				return new SpecialCharacterBoxElement(text);
-			}
+            if (ShowSpaces && c == ' ')
+            {
+                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                p.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+                return new SpaceTextElement(
+                    CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
+                        CurrentContext.TextView.Options.ShowSpacesGlyph,
+                        p));
+            }
+            else if (ShowTabs && c == '\t')
+            {
+                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                p.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+                return new TabTextElement(
+                    CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
+                        CurrentContext.TextView.Options.ShowTabsGlyph,
+                        p));
+            }
+            else if (ShowBoxForControlCharacters && char.IsControl(c))
+            {
+                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                p.SetForegroundBrush(Brushes.White);
+                var textFormatter = TextFormatterFactory.Create(CurrentContext.TextView);
+                var text = FormattedTextElement.PrepareText(textFormatter, TextUtilities.GetControlCharacterName(c), p);
+                return new SpecialCharacterBoxElement(text);
+            }
 
             return null;
-		}
+        }
 
-		private sealed class SpaceTextElement : FormattedTextElement
+        private sealed class SpaceTextElement : FormattedTextElement
 		{
 			public SpaceTextElement(TextLine textLine) : base(textLine, 1)
 			{
@@ -198,7 +212,7 @@ namespace AvaloniaEdit.Rendering
 			}
 		}
 
-		private sealed class SpecialCharacterBoxElement : FormattedTextElement
+		public sealed class SpecialCharacterBoxElement : FormattedTextElement
 		{
 			public SpecialCharacterBoxElement(TextLine text) : base(text, 1)
 			{

--- a/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
@@ -105,28 +105,26 @@ namespace AvaloniaEdit.Rendering
 
             if (ShowSpaces && c == ' ')
             {
-                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                p.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
-                return new SpaceTextElement(
-                    CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
+                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                runProperties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+                return new SpaceTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
                         CurrentContext.TextView.Options.ShowSpacesGlyph,
-                        p));
+                        runProperties));
             }
             else if (ShowTabs && c == '\t')
             {
-                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                p.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
-                return new TabTextElement(
-                    CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
+                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                runProperties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+                return new TabTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
                         CurrentContext.TextView.Options.ShowTabsGlyph,
-                        p));
+                        runProperties));
             }
             else if (ShowBoxForControlCharacters && char.IsControl(c))
             {
-                var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                p.SetForegroundBrush(Brushes.White);
+                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+                runProperties.SetForegroundBrush(Brushes.White);
                 var textFormatter = TextFormatterFactory.Create(CurrentContext.TextView);
-                var text = FormattedTextElement.PrepareText(textFormatter, TextUtilities.GetControlCharacterName(c), p);
+                var text = FormattedTextElement.PrepareText(textFormatter, TextUtilities.GetControlCharacterName(c), runProperties);
                 return new SpecialCharacterBoxElement(text);
             }
 

--- a/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
+++ b/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 
 using Avalonia.Media.TextFormatting;

--- a/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
+++ b/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
@@ -17,7 +17,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Generic;
-
 using Avalonia.Media.TextFormatting;
 
 namespace AvaloniaEdit.Rendering

--- a/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
+++ b/src/AvaloniaEdit/Rendering/TextViewCachedElements.cs
@@ -16,40 +16,29 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
+
 using Avalonia.Media.TextFormatting;
 
 namespace AvaloniaEdit.Rendering
 {
-    internal sealed class TextViewCachedElements /*: IDisposable*/
+    internal sealed class TextViewCachedElements
     {
-        private TextFormatter _formatter;
         private Dictionary<string, TextLine> _nonPrintableCharacterTexts;
 
-        public TextLine GetTextForNonPrintableCharacter(string text, ITextRunConstructionContext context)
+        public TextLine GetTextForNonPrintableCharacter(string text, TextRunProperties properties)
         {
             if (_nonPrintableCharacterTexts == null)
                 _nonPrintableCharacterTexts = new Dictionary<string, TextLine>();
+
             TextLine textLine;
-            if (!_nonPrintableCharacterTexts.TryGetValue(text, out textLine)) {
-                var p = new VisualLineElementTextRunProperties(context.GlobalTextRunProperties);
-                p.SetForegroundBrush(context.TextView.NonPrintableCharacterBrush);
-                if (_formatter == null)
-                    _formatter = TextFormatter.Current;//TextFormatterFactory.Create(context.TextView);
-                textLine = FormattedTextElement.PrepareText(_formatter, text, p);
+            if (!_nonPrintableCharacterTexts.TryGetValue(text, out textLine))
+            {
+                textLine = FormattedTextElement.PrepareText(TextFormatter.Current, text, properties);
                 _nonPrintableCharacterTexts[text] = textLine;
             }
             return textLine;
         }
-
-        /*public void Dispose()
-        {
-            if (nonPrintableCharacterTexts != null) {
-                foreach (TextLine line in nonPrintableCharacterTexts.Values)
-                    line.Dispose();
-            }
-            if (formatter != null)
-                formatter.Dispose();
-        }*/
     }
 }

--- a/src/AvaloniaEdit/Rendering/VisualLineTextSource.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLineTextSource.cs
@@ -18,6 +18,8 @@
 
 using System;
 using System.Diagnostics;
+
+using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Utilities;
 using AvaloniaEdit.Document;
@@ -74,30 +76,36 @@ namespace AvaloniaEdit.Rendering
 			}
 		}
 
-		private TextRun CreateTextRunForNewLine()
-		{
-			string newlineText = "";
-			DocumentLine lastDocumentLine = VisualLine.LastDocumentLine;
-			if (lastDocumentLine.DelimiterLength == 2) {
-				newlineText = "¶";
-			} else if (lastDocumentLine.DelimiterLength == 1) {
-				char newlineChar = Document.GetCharAt(lastDocumentLine.Offset + lastDocumentLine.Length);
-				if (newlineChar == '\r')
-					newlineText = "\\r";
-				else if (newlineChar == '\n')
-					newlineText = "\\n";
-				else
-					newlineText = "?";
-			}
+        private TextRun CreateTextRunForNewLine()
+        {
+            string newlineText = "";
+            DocumentLine lastDocumentLine = VisualLine.LastDocumentLine;
+            if (lastDocumentLine.DelimiterLength == 2)
+            {
+                newlineText = TextView.Options.EndOfLineCRLFGlyph;
+            }
+            else if (lastDocumentLine.DelimiterLength == 1)
+            {
+                char newlineChar = Document.GetCharAt(lastDocumentLine.Offset + lastDocumentLine.Length);
+                if (newlineChar == '\r')
+                    newlineText = TextView.Options.EndOfLineCRGlyph;
+                else if (newlineChar == '\n')
+                    newlineText = TextView.Options.EndOfLineLFGlyph;
+                else
+                    newlineText = "?";
+            }
 
-			var textElement = new FormattedTextElement(TextView.CachedElements.GetTextForNonPrintableCharacter(newlineText, this), 0);
+            var p = new VisualLineElementTextRunProperties(GlobalTextRunProperties);
+            p.SetForegroundBrush(TextView.NonPrintableCharacterBrush);
+            p.SetFontRenderingEmSize(GlobalTextRunProperties.FontRenderingEmSize - 2);
+            var textElement = new FormattedTextElement(TextView.CachedElements.GetTextForNonPrintableCharacter(newlineText, p), 0);
 
-			textElement.RelativeTextOffset = lastDocumentLine.Offset + lastDocumentLine.Length;
+            textElement.RelativeTextOffset = lastDocumentLine.Offset + lastDocumentLine.Length;
 
-			return new FormattedTextRun(textElement, GlobalTextRunProperties);
-		}
+            return new FormattedTextRun(textElement, GlobalTextRunProperties);
+        }
 
-		public ReadOnlySlice<char> GetPrecedingText(int textSourceCharacterIndexLimit)
+        public ReadOnlySlice<char> GetPrecedingText(int textSourceCharacterIndexLimit)
 		{
 			try {
 				foreach (VisualLineElement element in VisualLine.Elements) {

--- a/src/AvaloniaEdit/TextEditorOptions.cs
+++ b/src/AvaloniaEdit/TextEditorOptions.cs
@@ -81,7 +81,7 @@ namespace AvaloniaEdit
         private bool _showSpaces;
 
         /// <summary>
-        /// Gets/Sets whether to show · for spaces.
+        /// Gets/Sets whether to show a visible glyph for spaces. The glyph displayed can be set via <see cref="ShowSpacesGlyph" />
         /// </summary>
         /// <remarks>The default value is <c>false</c>.</remarks>
         [DefaultValue(false)]
@@ -98,10 +98,30 @@ namespace AvaloniaEdit
             }
         }
 
+        private string _showSpacesGlyph = "\u00B7";
+
+        /// <summary>
+        /// Gets/Sets the char to show when ShowSpaces option is enabled
+        /// </summary>
+        /// <remarks>The default value is <c>·</c>.</remarks>
+        [DefaultValue("\u00B7")]
+        public virtual string ShowSpacesGlyph
+        {
+            get { return _showSpacesGlyph; }
+            set
+            {
+                if (_showSpacesGlyph != value)
+                {
+                    _showSpacesGlyph = value;
+                    OnPropertyChanged("ShowSpacesGlyph");
+                }
+            }
+        }
+
         private bool _showTabs;
 
         /// <summary>
-        /// Gets/Sets whether to show » for tabs.
+        /// Gets/Sets whether to show a visible glyph for tab. The glyph displayed can be set via <see cref="ShowTabsGlyph" />
         /// </summary>
         /// <remarks>The default value is <c>false</c>.</remarks>
         [DefaultValue(false)]
@@ -118,10 +138,30 @@ namespace AvaloniaEdit
             }
         }
 
+        private string _showTabsGlyph = "\u2192";
+
+        /// <summary>
+        /// Gets/Sets the char to show when ShowTabs option is enabled
+        /// </summary>
+        /// <remarks>The default value is <c>→</c>.</remarks>
+        [DefaultValue("\u2192")]
+        public virtual string ShowTabsGlyph
+        {
+            get { return _showTabsGlyph; }
+            set
+            {
+                if (_showTabsGlyph != value)
+                {
+                    _showTabsGlyph = value;
+                    OnPropertyChanged("ShowTabsGlyph");
+                }
+            }
+        }
+
         private bool _showEndOfLine;
 
         /// <summary>
-        /// Gets/Sets whether to show ¶ at the end of lines.
+        /// Gets/Sets whether to show EOL char at the end of lines. The glyphs displayed can be set via <see cref="EndOfLineCRLFGlyph" />, <see cref="EndOfLineCRGlyph" /> and <see cref="EndOfLineLFGlyph" />.
         /// </summary>
         /// <remarks>The default value is <c>false</c>.</remarks>
         [DefaultValue(false)]
@@ -134,6 +174,66 @@ namespace AvaloniaEdit
                 {
                     _showEndOfLine = value;
                     OnPropertyChanged("ShowEndOfLine");
+                }
+            }
+        }
+
+        private string _endOfLineCRLFGlyph = "¶";
+
+        /// <summary>
+        /// Gets/Sets the char to show for CRLF (\r\n) when ShowEndOfLine option is enabled
+        /// </summary>
+        /// <remarks>The default value is <c>¶</c>.</remarks>
+        [DefaultValue("¶")]
+        public virtual string EndOfLineCRLFGlyph
+        {
+            get { return _endOfLineCRLFGlyph; }
+            set
+            {
+                if (_endOfLineCRLFGlyph != value)
+                {
+                    _endOfLineCRLFGlyph = value;
+                    OnPropertyChanged("CRLFGlyph");
+                }
+            }
+        }
+
+        private string _endOfLineCRGlyph = "\\r";
+
+        /// <summary>
+        /// Gets/Sets the char to show for CR (\r) when ShowEndOfLine option is enabled
+        /// </summary>
+        /// <remarks>The default value is <c>\r</c>.</remarks>
+        [DefaultValue("\\r")]
+        public virtual string EndOfLineCRGlyph
+        {
+            get { return _endOfLineCRGlyph; }
+            set
+            {
+                if (_endOfLineCRGlyph != value)
+                {
+                    _endOfLineCRGlyph = value;
+                    OnPropertyChanged("CRGlyph");
+                }
+            }
+        }
+
+        private string _endOfLineLFGlyph = "\\n";
+
+        /// <summary>
+        /// Gets/Sets the char to show for LF (\n) when ShowEndOfLine option is enabled
+        /// </summary>
+        /// <remarks>The default value is <c>\n</c>.</remarks>
+        [DefaultValue("\\n")]
+        public virtual string EndOfLineLFGlyph
+        {
+            get { return _endOfLineLFGlyph; }
+            set
+            {
+                if (_endOfLineLFGlyph != value)
+                {
+                    _endOfLineLFGlyph = value;
+                    OnPropertyChanged("LFGlyph");
                 }
             }
         }


### PR DESCRIPTION
This PR allows to configure the control chars displayed for spaces, tabs and EOL, via `TextEditorOptions`:
- **ShowSpaces**: Default character is `·`.
- **ShowTabs**: Default character is `→`.
- **ShowEndOfLine**:
    - _CRLF_: Default character is `¶`.
    - _CR_: Default character is ` \r`.
    - _LF_: Default character is ` \n`.

Additionally, this PR displays the EOL chars with smaller font size, to make the EOL glyphs less conspicuous, they were too big.

**Example**: Setting the following configuration for the demo application:
```
   _textEditor.Options.ShowSpacesGlyph = "o";
   _textEditor.Options.ShowTabsGlyph = ">";
   _textEditor.Options.EndOfLineCRGlyph = "CR";
   _textEditor.Options.EndOfLineLFGlyph = "LF";
   _textEditor.Options.EndOfLineCRLFGlyph = "CRLF";
```

Displays the control characters in the following way:
![customize-eol](https://user-images.githubusercontent.com/501613/196677259-4ea50770-8d31-4f08-b103-6c2f37643b39.gif)
