### PR TITLE
Allow multiple column rulers

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml
@@ -20,6 +20,7 @@
             <ToggleButton Name="viewTabs" Content="View tabs" IsChecked="{Binding #Editor.Options.ShowTabs}" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
             <ToggleButton Name="viewSpaces" Content="View spaces" IsChecked="{Binding #Editor.Options.ShowSpaces}" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
             <ToggleButton Name="viewEOL" Content="View EOL" IsChecked="{Binding #Editor.Options.ShowEndOfLine}" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
+            <ToggleButton Name="viewColumnRules" Content="View columns rulers" IsChecked="{Binding #Editor.Options.ShowColumnRulers}" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
             <Button Name="addControlBtn" Content="Add Button" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
             <Button Name="clearControlBtn" Content="Clear Buttons" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>
             <ComboBox Name="syntaxModeCombo" VerticalAlignment="Stretch" VerticalContentAlignment="Center"/>

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -60,6 +60,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
             _textEditor.Options.ShowBoxForControlCharacters = true;
+            _textEditor.Options.ColumnRulerPositions = new List<int>() { 80, 100 };
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy(_textEditor.Options);
             _textEditor.TextArea.Caret.PositionChanged += Caret_PositionChanged;
             _textEditor.TextArea.RightClickMovesCaret = true;
@@ -68,7 +69,7 @@ namespace AvaloniaEdit.Demo
             _addControlButton.Click += AddControlButton_Click;
 
             _clearControlButton = this.FindControl<Button>("clearControlBtn");
-            _clearControlButton.Click += ClearControlButton_Click; ;
+            _clearControlButton.Click += ClearControlButton_Click;
 
             _changeThemeButton = this.FindControl<Button>("changeThemeBtn");
             _changeThemeButton.Click += ChangeThemeButton_Click;

--- a/src/AvaloniaEdit/Rendering/ColumnRulerRenderer.cs
+++ b/src/AvaloniaEdit/Rendering/ColumnRulerRenderer.cs
@@ -17,56 +17,59 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
+
 using Avalonia;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
+
 using AvaloniaEdit.Utils;
 
 namespace AvaloniaEdit.Rendering
 {
-	/// <summary>
-	/// Renders a ruler at a certain column.
-	/// </summary>
-	internal sealed class ColumnRulerRenderer : IBackgroundRenderer
-	{
-		private IPen _pen;
-		private int _column;
-		private readonly TextView _textView;
+    /// <summary>
+    /// Renders a ruler at a certain column.
+    /// </summary>
+    internal sealed class ColumnRulerRenderer : IBackgroundRenderer
+    {
+        private IPen _pen;
+        private IEnumerable<int> _columns;
+        private readonly TextView _textView;
 
-		public static readonly Color DefaultForeground = Colors.LightGray;
+        public static readonly Color DefaultForeground = Colors.LightGray;
 
-		public ColumnRulerRenderer(TextView textView)
-		{
-			_pen = new ImmutablePen(new ImmutableSolidColorBrush(DefaultForeground), 1);
-			_textView = textView ?? throw new ArgumentNullException(nameof(textView));
-			_textView.BackgroundRenderers.Add(this);
-		}
+        public ColumnRulerRenderer(TextView textView)
+        {
+            _pen = new ImmutablePen(new ImmutableSolidColorBrush(DefaultForeground), 1);
+            _textView = textView ?? throw new ArgumentNullException(nameof(textView));
+            _textView.BackgroundRenderers.Add(this);
+        }
 
-		public KnownLayer Layer => KnownLayer.Background;
+        public KnownLayer Layer => KnownLayer.Background;
 
-		public void SetRuler(int column, IPen pen)
-		{
-			if (_column != column) {
-				_column = column;
-				_textView.InvalidateLayer(Layer);
-			}
-			if (_pen != pen) {
-				_pen = pen;
-				_textView.InvalidateLayer(Layer);
-			}
-		}
+        public void SetRuler(IEnumerable<int> columns, IPen pen)
+        {
+            _columns = columns;
+            _pen = pen;
+            _textView.InvalidateLayer(Layer);
+        }
 
-		public void Draw(TextView textView, DrawingContext drawingContext)
-		{
-			if (_column < 1) return;
-			var offset = textView.WideSpaceWidth * _column;
-			var pixelSize = PixelSnapHelpers.GetPixelSize(textView);
-			var markerXPos = PixelSnapHelpers.PixelAlign(offset, pixelSize.Width);
-			markerXPos -= textView.ScrollOffset.X;
-			var start = new Point(markerXPos, 0);
-			var end = new Point(markerXPos, Math.Max(textView.DocumentHeight, textView.Bounds.Height));
+        public void Draw(TextView textView, DrawingContext drawingContext)
+        {
+            if (_columns == null)
+                return;
 
-			drawingContext.DrawLine(_pen, start, end);
-		}
-	}
+            foreach (int column in _columns)
+            {
+                var offset = textView.WideSpaceWidth * column;
+                var pixelSize = PixelSnapHelpers.GetPixelSize(textView);
+                var markerXPos = PixelSnapHelpers.PixelAlign(offset, pixelSize.Width);
+                markerXPos -= textView.ScrollOffset.X;
+                var start = new Point(markerXPos, 0);
+                var end = new Point(markerXPos, Math.Max(textView.DocumentHeight, textView.Bounds.Height));
+
+                drawingContext.DrawLine(_pen, start, end);
+            }
+        }
+    }
 }

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -213,10 +213,10 @@ namespace AvaloniaEdit.Rendering
         {
             OptionChanged?.Invoke(this, e);
 
-            if (Options.ShowColumnRuler)
-                _columnRulerRenderer.SetRuler(Options.ColumnRulerPosition, ColumnRulerPen);
+            if (Options.ShowColumnRulers)
+                _columnRulerRenderer.SetRuler(Options.ColumnRulerPositions, ColumnRulerPen);
             else
-                _columnRulerRenderer.SetRuler(-1, ColumnRulerPen);
+                _columnRulerRenderer.SetRuler(null, ColumnRulerPen);
 
             UpdateBuiltinElementGeneratorsFromOptions();
             Redraw();
@@ -1928,7 +1928,7 @@ namespace AvaloniaEdit.Rendering
             }
             if (change.Property == ColumnRulerPenProperty)
             {
-                _columnRulerRenderer.SetRuler(Options.ColumnRulerPosition, ColumnRulerPen);
+                _columnRulerRenderer.SetRuler(Options.ColumnRulerPositions, ColumnRulerPen);
             }
             if (change.Property == CurrentLineBorderProperty)
             {
@@ -1942,10 +1942,10 @@ namespace AvaloniaEdit.Rendering
 
         /// <summary>
         /// The pen used to draw the column ruler.
-        /// <seealso cref="TextEditorOptions.ShowColumnRuler"/>
+        /// <seealso cref="TextEditorOptions.ShowColumnRulers"/>
         /// </summary>
         public static readonly StyledProperty<IPen> ColumnRulerPenProperty =
-            AvaloniaProperty.Register<TextView, IPen>("ColumnRulerBrush", CreateFrozenPen(Brushes.LightGray));
+            AvaloniaProperty.Register<TextView, IPen>("ColumnRulerBrush", CreateFrozenPen(new SolidColorBrush(Color.FromArgb(145, 128, 128, 128))));
 
         private static ImmutablePen CreateFrozenPen(IBrush brush)
         {
@@ -1988,7 +1988,7 @@ namespace AvaloniaEdit.Rendering
 
         /// <summary>
         /// Gets/Sets the pen used to draw the column ruler.
-        /// <seealso cref="TextEditorOptions.ShowColumnRuler"/>
+        /// <seealso cref="TextEditorOptions.ShowColumnRulers"/>
         /// </summary>
         public IPen ColumnRulerPen
         {

--- a/src/AvaloniaEdit/TextEditorOptions.cs
+++ b/src/AvaloniaEdit/TextEditorOptions.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 
@@ -564,40 +565,39 @@ namespace AvaloniaEdit
             }
         }
 
-        private bool _showColumnRuler;
+        private bool _showColumnRulers;
 
         /// <summary>
-        /// Gets/Sets whether the column ruler should be shown.
+        /// Gets/Sets whether the column rulers should be shown.
         /// </summary>
         [DefaultValue(false)]
-        public virtual bool ShowColumnRuler
+        public virtual bool ShowColumnRulers
         {
-            get { return _showColumnRuler; }
+            get { return _showColumnRulers; }
             set
             {
-                if (_showColumnRuler != value)
+                if (_showColumnRulers != value)
                 {
-                    _showColumnRuler = value;
-                    OnPropertyChanged("ShowColumnRuler");
+                    _showColumnRulers = value;
+                    OnPropertyChanged("ShowColumnRulers");
                 }
             }
         }
 
-        private int _columnRulerPosition = 80;
+        private IEnumerable<int> _columnRulerPositions = new List<int>() { 80 };
 
         /// <summary>
-        /// Gets/Sets where the column ruler should be shown.
+        /// Gets/Sets the positions the column rulers should be shown.
         /// </summary>
-        [DefaultValue(80)]
-        public virtual int ColumnRulerPosition
+        public virtual IEnumerable<int> ColumnRulerPositions
         {
-            get { return _columnRulerPosition; }
+            get { return _columnRulerPositions; }
             set
             {
-                if (_columnRulerPosition != value)
+                if (_columnRulerPositions != value)
                 {
-                    _columnRulerPosition = value;
-                    OnPropertyChanged("ColumnRulerPosition");
+                    _columnRulerPositions = value;
+                    OnPropertyChanged("ColumnRulerPositions");
                 }
             }
         }


### PR DESCRIPTION
- Allow multiple-column rulers instead of only one.
- Improve the foreground color.
- Add a sample to the demo project.

Demo:
![rulers](https://user-images.githubusercontent.com/501613/196721162-2276c670-043c-44b8-9648-de71e33cba7d.gif)
