### PR TITLE
Fixed lines not be highlighted sometimes

### DIFF
--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -27,6 +27,7 @@ namespace AvaloniaEdit.TextMate
         private TextView _textView;
         private Action<Exception> _exceptionHandler;
 
+        private volatile bool _areVisualLinesValid = false;
         private volatile int _firstVisibleLineIndex = -1;
         private volatile int _lastVisibleLineIndex = -1;
 
@@ -46,6 +47,7 @@ namespace AvaloniaEdit.TextMate
 
         public void SetModel(TextDocument document, TMModel model)
         {
+            _areVisualLinesValid = false;
             _document = document;
             _model = model;
 
@@ -62,6 +64,7 @@ namespace AvaloniaEdit.TextMate
                 if (!_textView.VisualLinesValid || _textView.VisualLines.Count == 0)
                     return;
 
+                _areVisualLinesValid = true;
                 _firstVisibleLineIndex = _textView.VisualLines[0].FirstDocumentLine.LineNumber - 1;
                 _lastVisibleLineIndex = _textView.VisualLines[_textView.VisualLines.Count - 1].LastDocumentLine.LineNumber - 1;
             }
@@ -216,8 +219,9 @@ namespace AvaloniaEdit.TextMate
             }
 
             bool changedLinesAreNotVisible =
-                (firstChangedLineIndex < _firstVisibleLineIndex && lastChangedLineIndex < _firstVisibleLineIndex) ||
-                (firstChangedLineIndex > _lastVisibleLineIndex && lastChangedLineIndex > _lastVisibleLineIndex);
+                _areVisualLinesValid &&
+                ((firstChangedLineIndex < _firstVisibleLineIndex && lastChangedLineIndex < _firstVisibleLineIndex) ||
+                (firstChangedLineIndex > _lastVisibleLineIndex && lastChangedLineIndex > _lastVisibleLineIndex));
 
             if (changedLinesAreNotVisible)
                 return;

--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -218,13 +218,15 @@ namespace AvaloniaEdit.TextMate
                 lastChangedLineIndex = Math.Max(range.ToLineNumber - 1, lastChangedLineIndex);
             }
 
-            bool changedLinesAreNotVisible =
-                _areVisualLinesValid &&
-                ((firstChangedLineIndex < _firstVisibleLineIndex && lastChangedLineIndex < _firstVisibleLineIndex) ||
-                (firstChangedLineIndex > _lastVisibleLineIndex && lastChangedLineIndex > _lastVisibleLineIndex));
+            if (_areVisualLinesValid)
+            {
+                bool changedLinesAreNotVisible =
+                    ((firstChangedLineIndex < _firstVisibleLineIndex && lastChangedLineIndex < _firstVisibleLineIndex) ||
+                    (firstChangedLineIndex > _lastVisibleLineIndex && lastChangedLineIndex > _lastVisibleLineIndex));
 
-            if (changedLinesAreNotVisible)
-                return;
+                if (changedLinesAreNotVisible)
+                    return;
+            }
 
             Dispatcher.UIThread.Post(() =>
             {


### PR DESCRIPTION
Fixed a condition that caused that some lines were not highlighted until they were re-created.

- Open a document of, let's say 500 lines and go to line 400 (visible range is 400-450).
- Open a document of 100 lines (first line is visible).
- When the `TMModel` starts to emit tokens, the visual lines haven't been constructed yet.

So `_firstVisibleLineIndex` and `_lastVisibleLineIndex` are not updated and still 400 and 450. So this condition avoids not post to the dispatcher the redraw

```csharp
    bool changedLinesAreNotVisible =
        (firstChangedLineIndex < _firstVisibleLineIndex && lastChangedLineIndex < _firstVisibleLineIndex) ||
        (firstChangedLineIndex > _lastVisibleLineIndex && lastChangedLineIndex > _lastVisibleLineIndex);

        if (changedLinesAreNotVisible)
            return;
```


**Solution:**
Just initialize control a flag `_areVisualLinesValid` and check it to calculate if `changedLinesAreNotVisible`. 
Otherwise, post all the redraw events to the dispatcher to ensure that lines are redrawn after transforming them.