### PR TITLE
When the control is not effectively visible the matrix could be null

### DIFF
--- a/src/AvaloniaEdit/Utils/ExtensionMethods.cs
+++ b/src/AvaloniaEdit/Utils/ExtensionMethods.cs
@@ -224,6 +224,9 @@ namespace AvaloniaEdit.Utils
             // Create a matrix to translate from control coordinates to device coordinates.
             var m = targetVisual.TransformToVisual((Control)root) * Matrix.CreateScale(scaling);
 
+            if (m == null)
+                return p;
+
             // Translate the point to device coordinates.
             var devicePoint = p.Transform(m.Value);
 


### PR DESCRIPTION
Avoid NRE.