### PR TITLE
Fix is replace mode

### DIFF
--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -110,17 +110,6 @@ namespace AvaloniaEdit.Search
         public static readonly StyledProperty<bool> IsReplaceModeProperty =
             AvaloniaProperty.Register<SearchPanel, bool>(nameof(IsReplaceMode));
 
-        
-        /// <summary>
-        /// Checks if replacemode is allowed
-        /// </summary>
-        /// <returns>False if editor is not null and readonly</returns>
-        private static bool ValidateReplaceMode(SearchPanel panel, bool v1)
-        {
-            if (panel._textEditor == null || !v1) return v1;
-            return !panel._textEditor.IsReadOnly;
-        }
-
         public bool IsReplaceMode
         {
             get => GetValue(IsReplaceModeProperty);

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -436,10 +436,15 @@ namespace AvaloniaEdit
         {
             if (e.Sender is TextEditor editor)
             {
-                if ((bool)e.NewValue)
-                    editor.TextArea.ReadOnlySectionProvider = ReadOnlySectionDocument.Instance;
-                else
-                    editor.TextArea.ReadOnlySectionProvider = NoReadOnlySections.Instance;
+                bool isReadonly = e.GetNewValue<bool>();
+
+                editor.TextArea.ReadOnlySectionProvider = isReadonly ?
+                    ReadOnlySectionDocument.Instance :
+                    NoReadOnlySections.Instance;
+
+                if (editor.SearchPanel != null)
+                    editor.SearchPanel.IsReplaceMode = isReadonly ?
+                        false : editor.SearchPanel.IsReplaceMode;
             }
         }
         #endregion


### PR DESCRIPTION
Fixes #315.

Set `SearchPanel.IsReplaceMode` to `false` when the `TextEditor.IsReadonly` is set to `true`. This causes the replace part of the search panel to be hidden when the editor is set to read only.