### PR TITLE
Add descriptions and license expressions to the nuget packages

### DIFF
--- a/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
+++ b/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Description>TextMate integration for AvaloniaEdit.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AvaloniaEdit/AvaloniaEdit.csproj
+++ b/src/AvaloniaEdit/AvaloniaEdit.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <WarningsNotAsErrors>0612,0618</WarningsNotAsErrors>
-	  <PackageId>Avalonia.AvaloniaEdit</PackageId>
+    <PackageId>Avalonia.AvaloniaEdit</PackageId>
+    <Description>This project is a port of AvalonEdit, a WPF-based text editor for Avalonia.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I was browsing nuget.org and noticed the generic desciptions fields on the packages:

![image](https://user-images.githubusercontent.com/1178570/229101486-551bc9eb-1d95-4168-bb82-56af395001c3.png)

So I thought I'd grab some text off the readme and add it as something a bit more useful, but then I noticed that the nuget.org listings don't specify what the license is, so I added PackageLicenseExpressions as well