### PR TITLE
Update TextMateSharp and drop Newtonsoft.Json

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AvaloniaVersion>11.0.0-preview6</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.50</TextMateSharpVersion>
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <TextMateSharpVersion>1.0.52</TextMateSharpVersion>
     <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Update TextMateSharp: the new version uses System.Text.Json instead of Newtonsoft.Json, and also brings trimming+AOT support