### PR TITLE
Expose IServiceContainer

### DIFF
--- a/src/AvaloniaEdit/Utils/IServiceContainer.cs
+++ b/src/AvaloniaEdit/Utils/IServiceContainer.cs
@@ -36,6 +36,12 @@ namespace AvaloniaEdit.Utils
     {
         private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
 
+        public ServiceContainer()
+        {
+            _services.Add(typeof(IServiceProvider), this);
+            _services.Add(typeof(IServiceContainer), this);
+        }
+
         public object GetService(Type serviceType)
         {
             _services.TryGetValue(serviceType, out var service);


### PR DESCRIPTION
WPF version allows to add other services into text editor, which was heavily used in our code

```csharp
TextEditor editor = ...;
editor.GetService<IServiceContainer>().AddService<MyServiceType>();
```