### PR TITLE
Pass the old new TextDocument on the DocumentChanged event

### DIFF
--- a/src/AvaloniaEdit/Document/DocumentChangedEventArgs.cs
+++ b/src/AvaloniaEdit/Document/DocumentChangedEventArgs.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace AvaloniaEdit.Document
+{
+    public class DocumentChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the old TextDocument.
+        /// </summary>
+        public TextDocument OldDocument { get; private set; }
+        /// <summary>
+        /// Gets the new TextDocument.
+        /// </summary>
+        public TextDocument NewDocument { get; private set; }
+
+        /// <summary>
+        /// Provides data for the <see cref="ITextEditorComponent.DocumentChanged"/> event.
+        /// </summary>
+        public DocumentChangedEventArgs(TextDocument oldDocument, TextDocument newDocument)
+        {
+            OldDocument = oldDocument;
+            NewDocument = newDocument;
+        }
+    }
+}

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -258,7 +258,7 @@ namespace AvaloniaEdit.Editing
         }
 
         /// <inheritdoc/>
-        public event EventHandler DocumentChanged;
+        public event EventHandler<DocumentChangedEventArgs> DocumentChanged;
 
         /// <summary>
         /// Gets if the the document displayed by the text editor is readonly
@@ -296,7 +296,7 @@ namespace AvaloniaEdit.Editing
             // in the new document (e.g. if new document is shorter than the old document).
             Caret.Location = new TextLocation(1, 1);
             ClearSelection();
-            DocumentChanged?.Invoke(this, EventArgs.Empty);
+            DocumentChanged?.Invoke(this, new DocumentChangedEventArgs(oldValue, newValue));
             //CommandManager.InvalidateRequerySuggested();
         }
         #endregion

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -130,7 +130,7 @@ namespace AvaloniaEdit.Rendering
         /// <summary>
         /// Occurs when the document property has changed.
         /// </summary>
-        public event EventHandler DocumentChanged;
+        public event EventHandler<DocumentChangedEventArgs> DocumentChanged;
 
         private static void OnDocumentChanged(AvaloniaPropertyChangedEventArgs e)
         {
@@ -159,7 +159,7 @@ namespace AvaloniaEdit.Rendering
                 CachedElements = new TextViewCachedElements();
             }
             InvalidateMeasure();
-            DocumentChanged?.Invoke(this, EventArgs.Empty);
+            DocumentChanged?.Invoke(this, new DocumentChangedEventArgs(oldValue, newValue));
         }
 
         private void RecreateCachedElements()

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -120,12 +120,12 @@ namespace AvaloniaEdit
         /// <summary>
         /// Occurs when the document property has changed.
         /// </summary>
-        public event EventHandler DocumentChanged;
+        public event EventHandler<DocumentChangedEventArgs> DocumentChanged;
 
         /// <summary>
         /// Raises the <see cref="DocumentChanged"/> event.
         /// </summary>
-        protected virtual void OnDocumentChanged(EventArgs e)
+        protected virtual void OnDocumentChanged(DocumentChangedEventArgs e)
         {
             DocumentChanged?.Invoke(this, e);
         }
@@ -148,7 +148,7 @@ namespace AvaloniaEdit
                 TextDocumentWeakEventManager.TextChanged.AddHandler(newValue, OnTextChanged);
                 PropertyChangedWeakEventManager.AddHandler(newValue.UndoStack, OnUndoStackPropertyChangedHandler);
             }
-            OnDocumentChanged(EventArgs.Empty);
+            OnDocumentChanged(new DocumentChangedEventArgs(oldValue, newValue));
             OnTextChanged(EventArgs.Empty);
         }
         #endregion

--- a/src/AvaloniaEdit/TextEditorComponent.cs
+++ b/src/AvaloniaEdit/TextEditorComponent.cs
@@ -39,7 +39,7 @@ namespace AvaloniaEdit
 		/// Occurs when the Document property changes (when the text editor is connected to another
 		/// document - not when the document content changes).
 		/// </summary>
-		event EventHandler DocumentChanged;
+		event EventHandler<DocumentChangedEventArgs> DocumentChanged;
 		
 		/// <summary>
 		/// Gets the options of the text editor.


### PR DESCRIPTION
Sometimes one requires to subscribe to events existing inside the `TextDocument` and maybe you're interested in unsubscribing the events in the old document before subscribing to the events in the new document.

For that purpose, I just extended the `EventArgs` used for the `DocumentChanged` event to pass the old document and the new document.