### PR TITLE
Change ICompletionData.Image from Bitmap to IImage

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -347,7 +347,7 @@ namespace AvaloniaEdit.Demo
                 Text = text;
             }
 
-            public Bitmap Image => null;
+            public IImage Image => null;
 
             public string Text { get; }
 

--- a/src/AvaloniaEdit/CodeCompletion/ICompletionData.cs
+++ b/src/AvaloniaEdit/CodeCompletion/ICompletionData.cs
@@ -17,9 +17,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using Avalonia.Media;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Editing;
-using Avalonia.Media.Imaging;
 
 namespace AvaloniaEdit.CodeCompletion
 {
@@ -35,7 +35,7 @@ namespace AvaloniaEdit.CodeCompletion
         /// <summary>
         /// Gets the image.
         /// </summary>
-        Bitmap Image { get; }
+        IImage Image { get; }
 		
 		/// <summary>
 		/// Gets the text. This property is used to filter the list of visible elements.


### PR DESCRIPTION
I propose changing `ICompletionData.Image` from `Bitmap` to `IImage`. Having `Bitmap` in the interface is unnecessarily restrictive. Changing the type to `IImage` allows other types of image sources. For example: `CroppedBitmap`, `DrawingImage`

In my case, I have an icon font that has a custom `IImage` implementation.

⚠ Note that this is a breaking change! Any application implementing `IComplectionData` (like AvaloniaEdit.Demo) will have to be updated. However, I think that this change is worthwhile and should be made before releasing 11.0.0.