### PR TITLE
Fix: TextLayer is rendered behind SelectionLayer

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -348,7 +348,7 @@ namespace AvaloniaEdit.Rendering
             protected override void InsertItem(int index, Control item)
             {
                 base.InsertItem(index, item);
-                _textView.VisualChildren.Add(item);
+                _textView.VisualChildren.Insert(index, item);
                 _textView.LayersChanged();
             }
 


### PR DESCRIPTION
**Problem:**
The `TextLayer` is rendered behind the `SelectionLayer`, which makes the text hard to read when selected. If you style the control and set an opaque `SelectionBrush` then the text is obscured completely.

**Cause:**
The problem is that `TextView.Layers` and `TextView.VisualChildren` are out of sync: 
The `Layers` are 

1. `SelectionLayer`
1. `TextLayer`
1. `CaretLayer`

but the `VisualChildren` are

1. `TextLayer`
1. `SelectionLayer`
1. `CaretLayer`

**Fix:**
The `LayerCollection` needs to insert the control at the correct index. (The first *n* visual children should correspond to the *n* layers in the `LayerCollection`.)