### PR TITLE
Fix: Column ruler behind current line highlight

### DIFF
--- a/src/AvaloniaEdit/Rendering/CurrentLineHighlightRenderer.cs
+++ b/src/AvaloniaEdit/Rendering/CurrentLineHighlightRenderer.cs
@@ -47,7 +47,7 @@ namespace AvaloniaEdit.Rendering
             }
         }
 
-        public KnownLayer Layer => KnownLayer.Selection;
+        public KnownLayer Layer => KnownLayer.Background;
 
         public IBrush BackgroundBrush {
             get; set;

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -66,7 +66,7 @@ namespace AvaloniaEdit.Rendering
         }
 
         private readonly ColumnRulerRenderer _columnRulerRenderer;
-        private readonly CurrentLineHighlightRenderer _currentLineHighlighRenderer;
+        private readonly CurrentLineHighlightRenderer _currentLineHighlightRenderer;
 
         /// <summary>
         /// Creates a new TextView instance.
@@ -79,8 +79,8 @@ namespace AvaloniaEdit.Rendering
             _elementGenerators = new ObserveAddRemoveCollection<VisualLineElementGenerator>(ElementGenerator_Added, ElementGenerator_Removed);
             _lineTransformers = new ObserveAddRemoveCollection<IVisualLineTransformer>(LineTransformer_Added, LineTransformer_Removed);
             _backgroundRenderers = new ObserveAddRemoveCollection<IBackgroundRenderer>(BackgroundRenderer_Added, BackgroundRenderer_Removed);
+            _currentLineHighlightRenderer = new CurrentLineHighlightRenderer(this);
             _columnRulerRenderer = new ColumnRulerRenderer(this);
-            _currentLineHighlighRenderer = new CurrentLineHighlightRenderer(this);
             Options = new TextEditorOptions();
 
             Debug.Assert(_singleCharacterElementGenerator != null); // assert that the option change created the builtin element generators
@@ -1929,11 +1929,11 @@ namespace AvaloniaEdit.Rendering
             }
             if (change.Property == CurrentLineBorderProperty)
             {
-                _currentLineHighlighRenderer.BorderPen = CurrentLineBorder;
+                _currentLineHighlightRenderer.BorderPen = CurrentLineBorder;
             }
             if (change.Property == CurrentLineBackgroundProperty)
             {
-                _currentLineHighlighRenderer.BackgroundBrush = CurrentLineBackground;
+                _currentLineHighlightRenderer.BackgroundBrush = CurrentLineBackground;
             }
         }
 
@@ -2028,8 +2028,8 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         public int HighlightedLine
         {
-            get => _currentLineHighlighRenderer.Line;
-            set => _currentLineHighlighRenderer.Line = value;
+            get => _currentLineHighlightRenderer.Line;
+            set => _currentLineHighlightRenderer.Line = value;
         }
 
         /// <summary>


### PR DESCRIPTION
**Problem:**
The vertical column ruler is rendered behind the current line highlight.

**Fix:**
I suggest changing `CurrentLineHighlightRenderer.Layer` to `KnownLayer.Background`. This way, the vertical column ruler and other highlights (such as search result markers) can be rendered on top.

In `TextView` the `ColumnRulerRenderer` needs to be registered after the `CurrentLineHighlightRenderer`.

Also fixed a typo in the existing code.