### PR TITLE
Fix CS0618: Interface 'Avalonia.Styling.IStyleable' is obsolete

### DIFF
--- a/src/AvaloniaEdit/CodeCompletion/CompletionListBox.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionListBox.cs
@@ -19,7 +19,6 @@
 using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Styling;
 using AvaloniaEdit.Utils;
 
 namespace AvaloniaEdit.CodeCompletion
@@ -27,11 +26,11 @@ namespace AvaloniaEdit.CodeCompletion
     /// <summary>
     /// The list box used inside the CompletionList.
     /// </summary>
-    public class CompletionListBox : ListBox, IStyleable
+    public class CompletionListBox : ListBox
     {
         internal ScrollViewer ScrollViewer;
 
-        Type IStyleable.StyleKey => typeof(ListBox);
+        protected override Type StyleKeyOverride  => typeof(ListBox);
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {

--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
@@ -29,7 +29,6 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
-using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
@@ -38,14 +37,14 @@ namespace AvaloniaEdit.CodeCompletion
     /// <summary>
     /// Base class for completion windows. Handles positioning the window at the caret.
     /// </summary>
-    public class CompletionWindowBase : Popup, IStyleable
+    public class CompletionWindowBase : Popup
     {
         static CompletionWindowBase()
         {
             //BackgroundProperty.OverrideDefaultValue(typeof(CompletionWindowBase), Brushes.White);           
         }
 
-        Type IStyleable.StyleKey => typeof(PopupRoot);
+        protected override Type StyleKeyOverride => typeof(PopupRoot);
 
         /// <summary>
         /// Gets the parent TextArea.


### PR DESCRIPTION
This PR replaces `IStyleable` with `StyleKeyOverride` to remove the warnings.

`IStyleable` is deprecated in Avalonia UI 11.0.0 RC1. See https://github.com/AvaloniaUI/Avalonia/wiki/Avalonia-11-Porting-Guide#optional-but-recommended.