### PR TITLE
Fix NRE on losing focus #359

### DIFF
--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -1192,7 +1192,12 @@ namespace AvaloniaEdit.Editing
 
             public override TextSelection Selection
             {
-                get => new TextSelection(_textArea.Caret.Position.Column, _textArea.Caret.Position.Column + _textArea.Selection.Length);
+                get
+                {
+                    if (_textArea == null)
+                        return new TextSelection(0, 0);
+                    return new TextSelection(_textArea.Caret.Position.Column, _textArea.Caret.Position.Column + _textArea.Selection.Length);
+                }
                 set
                 {
                     var selection = _textArea.Selection;


### PR DESCRIPTION
This pull request fixes issue #359 . It uses default TextSelection(0, 0) for the case when TextArea is null, and thus prevents NRE.

I tested this a bit and it looks like it does not break things.