### PR TITLE
Bump dependency version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AvaloniaVersion>11.0.4</AvaloniaVersion>
-    <TextMateSharpVersion>1.0.55</TextMateSharpVersion>
+    <AvaloniaVersion>11.0.5</AvaloniaVersion>
+    <TextMateSharpVersion>1.0.56</TextMateSharpVersion>
     <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
AOT requires using TextMateSharp 1.0.56+, otherwise it will fail to load grammar definitions.

I would like to see a new version of AvaloniaEdit being released soon to fix this AOT issue.