### PR TITLE
Fix replace next functionality

### DIFF
--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -371,12 +371,19 @@ namespace AvaloniaEdit.Search
                 foreach (var result in _strategy.FindAll(_textArea.Document, 0, _textArea.Document.TextLength).Cast<SearchResult>())
                 {
                     _renderer.CurrentResults.Add(result);
-                    if (changeSelection && result.StartOffset >= offset)
-                    {
+                }
+
+                if (changeSelection)
+                {
+                    // select the first result after the caret position
+                    // or the first result in document order if there is no result after the caret
+                    var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(offset) ??
+                                 _renderer.CurrentResults.FirstSegment;
+
+                    if (result != null)
                         SelectResult(result);
-                        _currentSearchResultIndex = _renderer.CurrentResults.Count - 1;
-                        changeSelection = false;
-                    }
+
+                    _currentSearchResultIndex = _renderer.CurrentResults.Count - 1;
                 }
             }
 

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -282,24 +282,11 @@ namespace AvaloniaEdit.Search
         }
 
         /// <summary>
-        /// Moves to the next occurrence in the file starting at current caret offset.
-        /// </summary>
-        public void Find()
-        {
-            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset) ??
-                         _renderer.CurrentResults.FirstSegment;
-            if (result != null)
-            {
-                SetCurrentSearchResult(result);
-            }
-        }
-
-        /// <summary>
         /// Moves to the next occurrence in the file starting at the next position from current caret offset.
         /// </summary>
         public void FindNext()
         {
-            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset + 1) ??
+            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset) ??
                          _renderer.CurrentResults.FirstSegment;
             if (result != null)
             {
@@ -312,7 +299,8 @@ namespace AvaloniaEdit.Search
         /// </summary>
         public void FindPrevious()
         {
-            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset);
+            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(
+                Math.Max(_textArea.Caret.Offset - _textArea.Selection.Length, 0));
             if (result != null)
                 result = _renderer.CurrentResults.GetPreviousSegment(result);
             if (result == null)
@@ -327,7 +315,7 @@ namespace AvaloniaEdit.Search
         {
             if (!IsReplaceMode) return;
 
-            Find();
+            FindNext();
             if (!_textArea.Selection.IsEmpty)
             {
                 _textArea.Selection.ReplaceSelectionWithText(ReplacePattern ?? string.Empty);
@@ -372,7 +360,7 @@ namespace AvaloniaEdit.Search
 
             if (!string.IsNullOrEmpty(SearchPattern))
             {
-                var offset = _textArea.Caret.Offset;
+                var offset = Math.Max(_textArea.Caret.Offset - SearchPattern.Length, 0);
                 if (changeSelection)
                 {
                     _textArea.ClearSelection();
@@ -437,7 +425,7 @@ namespace AvaloniaEdit.Search
 
         private void SelectResult(TextSegment result)
         {
-            _textArea.Caret.Offset = result.StartOffset;
+            _textArea.Caret.Offset = result.EndOffset;
             _textArea.Selection = Selection.Create(_textArea, result.StartOffset, result.EndOffset);
 
             double distanceToViewBorder = _border == null ?

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -358,14 +358,15 @@ namespace AvaloniaEdit.Search
 
             CleanSearchResults();
 
+            var offset = Math.Max(_textArea.Caret.Offset - _textArea.Selection.Length, 0);
+
+            if (changeSelection)
+            {
+                _textArea.ClearSelection();
+            }
+            
             if (!string.IsNullOrEmpty(SearchPattern))
             {
-                var offset = Math.Max(_textArea.Caret.Offset - SearchPattern.Length, 0);
-                if (changeSelection)
-                {
-                    _textArea.ClearSelection();
-                }
-
                 // We cast from ISearchResult to SearchResult; this is safe because we always use the built-in strategy
                 foreach (var result in _strategy.FindAll(_textArea.Document, 0, _textArea.Document.TextLength).Cast<SearchResult>())
                 {

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -284,9 +284,9 @@ namespace AvaloniaEdit.Search
         /// <summary>
         /// Moves to the next occurrence in the file starting at the next position from current caret offset.
         /// </summary>
-        public void FindNext()
+        public void FindNext(int startOffset = -1)
         {
-            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset) ??
+            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(startOffset == -1 ? _textArea.Caret.Offset : startOffset) ??
                          _renderer.CurrentResults.FirstSegment;
             if (result != null)
             {
@@ -315,7 +315,7 @@ namespace AvaloniaEdit.Search
         {
             if (!IsReplaceMode) return;
 
-            FindNext();
+            FindNext(Math.Max(_textArea.Caret.Offset - _textArea.Selection.Length, 0));
             if (!_textArea.Selection.IsEmpty)
             {
                 _textArea.Selection.ReplaceSelectionWithText(ReplacePattern ?? string.Empty);

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -144,7 +144,6 @@ namespace AvaloniaEdit.Search
         {
             if (e.Sender is SearchPanel panel)
             {
-                panel.ValidateSearchText();
                 panel.UpdateSearch();
             }
         }
@@ -268,14 +267,6 @@ namespace AvaloniaEdit.Search
             _searchTextBox = e.NameScope.Find<TextBox>("PART_searchTextBox");
             _messageView = e.NameScope.Find<Panel>("PART_MessageView");
             _messageViewContent = e.NameScope.Find<TextBlock>("PART_MessageContent");
-        }
-
-        private void ValidateSearchText()
-        {
-            if (_searchTextBox == null)
-                return;
-
-            UpdateSearch();
         }
 
         /// <summary>

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -291,7 +291,20 @@ namespace AvaloniaEdit.Search
         }
 
         /// <summary>
-        /// Moves to the next occurrence in the file.
+        /// Moves to the next occurrence in the file starting at current caret offset.
+        /// </summary>
+        public void Find()
+        {
+            var result = _renderer.CurrentResults.FindFirstSegmentWithStartAfter(_textArea.Caret.Offset) ??
+                         _renderer.CurrentResults.FirstSegment;
+            if (result != null)
+            {
+                SetCurrentSearchResult(result);
+            }
+        }
+
+        /// <summary>
+        /// Moves to the next occurrence in the file starting at the next position from current caret offset.
         /// </summary>
         public void FindNext()
         {
@@ -323,7 +336,7 @@ namespace AvaloniaEdit.Search
         {
             if (!IsReplaceMode) return;
 
-            FindNext();
+            Find();
             if (!_textArea.Selection.IsEmpty)
             {
                 _textArea.Selection.ReplaceSelectionWithText(ReplacePattern ?? string.Empty);

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -156,7 +156,7 @@ namespace AvaloniaEdit.Search
             // if results are found by the next run, the message will be hidden inside DoSearch ...
             try
             {
-                if (_renderer.CurrentResults.Any())
+                if (_renderer.CurrentResults.Any() && _messageView != null)
                     _messageView.IsVisible = false;
                 _strategy = SearchStrategyFactory.Create(SearchPattern ?? "", !MatchCase, WholeWords, UseRegex ? SearchMode.RegEx : SearchMode.Normal);
                 OnSearchOptionsChanged(new SearchOptionsChangedEventArgs(SearchPattern, MatchCase, UseRegex, WholeWords));
@@ -480,7 +480,10 @@ namespace AvaloniaEdit.Search
         public void Close()
         {
             _textArea.RemoveChild(this);
-            _messageView.IsVisible = false;
+
+            if (_messageView != null)
+                _messageView.IsVisible = false;
+
             _textArea.TextView.BackgroundRenderers.Remove(_renderer);
             
             IsClosed = true;

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -299,9 +299,7 @@ namespace AvaloniaEdit.Search
                          _renderer.CurrentResults.FirstSegment;
             if (result != null)
             {
-                _currentSearchResultIndex = GetSearchResultIndex(_renderer.CurrentResults, result);
-                SelectResult(result);
-                UpdateSearchLabel();
+                SetCurrentSearchResult(result);
             }
         }
 
@@ -317,9 +315,7 @@ namespace AvaloniaEdit.Search
                 result = _renderer.CurrentResults.LastSegment;
             if (result != null)
             {
-                _currentSearchResultIndex = GetSearchResultIndex(_renderer.CurrentResults, result);
-                SelectResult(result);
-                UpdateSearchLabel();
+                SetCurrentSearchResult(result);
             }
         }
 
@@ -355,6 +351,13 @@ namespace AvaloniaEdit.Search
 
         private Panel _messageView;
         private TextBlock _messageViewContent;
+
+        private void SetCurrentSearchResult(SearchResult result)
+        {
+            _currentSearchResultIndex = GetSearchResultIndex(_renderer.CurrentResults, result);
+            SelectResult(result);
+            UpdateSearchLabel();
+        }
 
         private void DoSearch(bool changeSelection)
         {

--- a/test/AvaloniaEdit.Tests/AvaloniaMocks/UnitTestApplication.cs
+++ b/test/AvaloniaEdit.Tests/AvaloniaMocks/UnitTestApplication.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia;
+﻿using System;
+using Avalonia;
 using Avalonia.Headless;
+using Avalonia.Markup.Xaml.Styling;
 using AvaloniaEdit.AvaloniaMocks;
 
 [assembly: AvaloniaTestApplication(typeof(UnitTestApplication))]
@@ -8,12 +10,21 @@ namespace AvaloniaEdit.AvaloniaMocks
 {
     public class UnitTestApplication : Application
     {
-
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<UnitTestApplication>()
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions
                 {
                     UseHeadlessDrawing = true
                 });
+
+        public static void InitializeStyles()
+        {
+            ResourceInclude styleInclude = new ResourceInclude(new Uri("avares://AvaloniaEdit"))
+            {
+                Source = new Uri("/Themes/Base.xaml", UriKind.Relative)
+            };
+
+            Application.Current?.Resources.MergedDictionaries.Add(styleInclude);
+        }
     }
 }

--- a/test/AvaloniaEdit.Tests/Search/FindTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/FindTests.cs
@@ -23,107 +23,107 @@ using NUnit.Framework;
 
 namespace AvaloniaEdit.Search
 {
-	//[TestFixture]
-	//public class FindTests
-	//{
-	//	[Test]
-	//	public void SkipWordBorderSimple()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("All", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource(" FindAllTests ");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.IsEmpty(results, "No results should be found!");
-	//	}
-		
-	//	[Test]
-	//	public void SkipWordBorder()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("AllTests", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("name=\"{FindAllTests}\"");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.IsEmpty(results, "No results should be found!");
-	//	}
-		
-	//	[Test]
-	//	public void SkipWordBorder2()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("AllTests", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("name=\"FindAllTests ");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.IsEmpty(results, "No results should be found!");
-	//	}
-		
-	//	[Test]
-	//	public void SkipWordBorder3()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("// find", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("            // findtest");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.IsEmpty(results, "No results should be found!");
-	//	}
-		
-	//	[Test]
-	//	public void WordBorderTest()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("// find", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("            // find me");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.AreEqual(1, results.Length, "One result should be found!");
-	//		Assert.AreEqual("            ".Length, results[0].Offset);
-	//		Assert.AreEqual("// find".Length, results[0].Length);
-	//	}
-		
-	//	[Test]
-	//	public void ResultAtStart()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("result", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("result           // find me");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.AreEqual(1, results.Length, "One result should be found!");
-	//		Assert.AreEqual(0, results[0].Offset);
-	//		Assert.AreEqual("result".Length, results[0].Length);
-	//	}
-		
-	//	[Test]
-	//	public void ResultAtEnd()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("me", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource("result           // find me");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.AreEqual(1, results.Length, "One result should be found!");
-	//		Assert.AreEqual("result           // find ".Length, results[0].Offset);
-	//		Assert.AreEqual("me".Length, results[0].Length);
-	//	}
-		
-	//	[Test]
-	//	public void TextWithDots()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("Text", false, true, SearchMode.Normal);
-	//		var text = new StringTextSource(".Text.");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.AreEqual(1, results.Length, "One result should be found!");
-	//		Assert.AreEqual(".".Length, results[0].Offset);
-	//		Assert.AreEqual("Text".Length, results[0].Length);
-	//	}
-		
-	//	[Test]
-	//	public void SimpleTest()
-	//	{
-	//		var strategy = SearchStrategyFactory.Create("AllTests", false, false, SearchMode.Normal);
-	//		var text = new StringTextSource("name=\"FindAllTests ");
-	//		var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
-			
-	//		Assert.AreEqual(1, results.Length, "One result should be found!");
-	//		Assert.AreEqual("name=\"Find".Length, results[0].Offset);
-	//		Assert.AreEqual("AllTests".Length, results[0].Length);
-	//	}
-	//}
+    [TestFixture]
+    public class FindTests
+    {
+        [Test]
+        public void SkipWordBorderSimple()
+        {
+            var strategy = SearchStrategyFactory.Create("All", false, true, SearchMode.Normal);
+            var text = new StringTextSource(" FindAllTests ");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.IsEmpty(results, "No results should be found!");
+        }
+
+        [Test]
+        public void SkipWordBorder()
+        {
+            var strategy = SearchStrategyFactory.Create("AllTests", false, true, SearchMode.Normal);
+            var text = new StringTextSource("name=\"{FindAllTests}\"");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.IsEmpty(results, "No results should be found!");
+        }
+
+        [Test]
+        public void SkipWordBorder2()
+        {
+            var strategy = SearchStrategyFactory.Create("AllTests", false, true, SearchMode.Normal);
+            var text = new StringTextSource("name=\"FindAllTests ");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.IsEmpty(results, "No results should be found!");
+        }
+
+        [Test]
+        public void SkipWordBorder3()
+        {
+            var strategy = SearchStrategyFactory.Create("// find", false, true, SearchMode.Normal);
+            var text = new StringTextSource("            // findtest");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.IsEmpty(results, "No results should be found!");
+        }
+
+        [Test]
+        public void WordBorderTest()
+        {
+            var strategy = SearchStrategyFactory.Create("// find", false, true, SearchMode.Normal);
+            var text = new StringTextSource("            // find me");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.AreEqual(1, results.Length, "One result should be found!");
+            Assert.AreEqual("            ".Length, results[0].Offset);
+            Assert.AreEqual("// find".Length, results[0].Length);
+        }
+
+        [Test]
+        public void ResultAtStart()
+        {
+            var strategy = SearchStrategyFactory.Create("result", false, true, SearchMode.Normal);
+            var text = new StringTextSource("result           // find me");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.AreEqual(1, results.Length, "One result should be found!");
+            Assert.AreEqual(0, results[0].Offset);
+            Assert.AreEqual("result".Length, results[0].Length);
+        }
+
+        [Test]
+        public void ResultAtEnd()
+        {
+            var strategy = SearchStrategyFactory.Create("me", false, true, SearchMode.Normal);
+            var text = new StringTextSource("result           // find me");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.AreEqual(1, results.Length, "One result should be found!");
+            Assert.AreEqual("result           // find ".Length, results[0].Offset);
+            Assert.AreEqual("me".Length, results[0].Length);
+        }
+
+        [Test]
+        public void TextWithDots()
+        {
+            var strategy = SearchStrategyFactory.Create("Text", false, true, SearchMode.Normal);
+            var text = new StringTextSource(".Text.");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.AreEqual(1, results.Length, "One result should be found!");
+            Assert.AreEqual(".".Length, results[0].Offset);
+            Assert.AreEqual("Text".Length, results[0].Length);
+        }
+
+        [Test]
+        public void SimpleTest()
+        {
+            var strategy = SearchStrategyFactory.Create("AllTests", false, false, SearchMode.Normal);
+            var text = new StringTextSource("name=\"FindAllTests ");
+            var results = strategy.FindAll(text, 0, text.TextLength).ToArray();
+
+            Assert.AreEqual(1, results.Length, "One result should be found!");
+            Assert.AreEqual("name=\"Find".Length, results[0].Offset);
+            Assert.AreEqual("AllTests".Length, results[0].Length);
+        }
+    }
 }

--- a/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
@@ -117,6 +117,22 @@ public class SearchPanelTests
     }
 
     [AvaloniaTest]
+    public void Clear_Search_Pattern_Should_Clean_Selection()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world";
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+
+        textEditor.SearchPanel.SearchPattern = "";
+
+        Assert.AreEqual(0, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
     public void Replace_All_Should_Replace_All_Occurences()
     {
         UnitTestApplication.InitializeStyles();

--- a/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
@@ -25,6 +25,23 @@ public class SearchPanelTests
     }
 
     [AvaloniaTest]
+    public void Find_Next_After_Find_Next_Should_Find_The_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world world";
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindNext();
+        textEditor.SearchPanel.FindNext();
+
+        Assert.AreEqual(12, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
     public void Find_Previous_Should_Find_Previous_Occurence()
     {
         UnitTestApplication.InitializeStyles();
@@ -39,6 +56,25 @@ public class SearchPanelTests
         textEditor.SearchPanel.FindPrevious();
 
         Assert.AreEqual(0, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
+    public void Find_Previous_After_Find_Previous_Should_Find_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world world";
+
+        textEditor.CaretOffset = 17;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindPrevious();
+        textEditor.SearchPanel.FindPrevious();
+
+        Assert.AreEqual(6, textEditor.SelectionStart);
         Assert.AreEqual(5, textEditor.SelectionLength);
     }
 

--- a/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
@@ -1,0 +1,112 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using AvaloniaEdit.AvaloniaMocks;
+using NUnit.Framework;
+
+namespace AvaloniaEdit.Search;
+
+[TestFixture]
+public class SearchPanelTests
+{
+    [AvaloniaTest]
+    public void Find_Next_Should_Find_Next_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world";
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindNext();
+
+        Assert.AreEqual(6, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
+    public void Find_Previous_Should_Find_Previous_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world";
+
+        textEditor.CaretOffset = 6;
+
+        textEditor.SearchPanel.SearchPattern = "hello";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindPrevious();
+
+        Assert.AreEqual(0, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
+    public void Replace_Next_Should_Replace_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world";
+
+        textEditor.CaretOffset = 6;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.ReplacePattern = "universe";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.IsReplaceMode = true;
+        textEditor.SearchPanel.ReplaceNext();
+
+        Assert.AreEqual("hello universe", textEditor.Text);
+    }
+
+    [AvaloniaTest]
+    public void Replace_Next_Should_Replace_Occurence_At_Caret_Index()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world world";
+
+        textEditor.CaretOffset = 6;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.ReplacePattern = "universe";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.IsReplaceMode = true;
+        textEditor.SearchPanel.ReplaceNext();
+
+        Assert.AreEqual("hello universe world", textEditor.Text);
+    }
+
+    [AvaloniaTest]
+    public void Replace_All_Should_Replace_All_Occurences()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world hello world";
+
+        textEditor.SearchPanel.SearchPattern = "hello";
+        textEditor.SearchPanel.ReplacePattern = "bye";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.IsReplaceMode = true;
+        textEditor.SearchPanel.ReplaceAll();
+
+        Assert.AreEqual("bye world bye world", textEditor.Text);
+    }
+
+    static TextEditor CreateEditor()
+    {
+        TextEditor textEditor = new TextEditor();
+
+        Window window = new Window();
+        window.Content = textEditor;
+
+        window.Show();
+        textEditor.ApplyTemplate();
+
+        return textEditor;
+    }
+}

--- a/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
@@ -135,6 +135,26 @@ public class SearchPanelTests
     }
 
     [AvaloniaTest]
+    public void Replace_Next_After_Replace_Next_Should_Replace_Occurence()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world world world";
+
+        textEditor.CaretOffset = 6;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.ReplacePattern = "universe";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.IsReplaceMode = true;
+        textEditor.SearchPanel.ReplaceNext();
+        textEditor.SearchPanel.ReplaceNext();
+
+        Assert.AreEqual("hello universe universe world", textEditor.Text);
+    }
+
+    [AvaloniaTest]
     public void Replace_Next_Should_Replace_Occurence_At_Caret_Index()
     {
         UnitTestApplication.InitializeStyles();

--- a/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
+++ b/test/AvaloniaEdit.Tests/Search/SearchPanelTests.cs
@@ -60,6 +60,43 @@ public class SearchPanelTests
     }
 
     [AvaloniaTest]
+    public void Find_Should_Select_The_First_Result_After_Caret()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world world";
+
+        textEditor.CaretOffset = 6;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindNext();
+
+        Assert.AreEqual(6, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+    }
+
+    [AvaloniaTest]
+    public void Find_Should_Select_First_Result_When_There_Are_No_Results_After_Caret()
+    {
+        UnitTestApplication.InitializeStyles();
+
+        TextEditor textEditor = CreateEditor();
+        textEditor.Text = "hello world lovely";
+
+        textEditor.CaretOffset = 12;
+
+        textEditor.SearchPanel.SearchPattern = "world";
+        textEditor.SearchPanel.Open();
+        textEditor.SearchPanel.FindNext();
+
+        Assert.AreEqual(6, textEditor.SelectionStart);
+        Assert.AreEqual(5, textEditor.SelectionLength);
+
+    }
+
+    [AvaloniaTest]
     public void Find_Previous_After_Find_Previous_Should_Find_Occurence()
     {
         UnitTestApplication.InitializeStyles();


### PR DESCRIPTION
If you had a text that contains multiple matches and replace one by one using the "Replace next" button it skips one of the matches each time (see #355).

Changes on this PR:

* Re-enable existing (but commented) `FindTests`.
* Added unit tests to cover this functionality.
* Fixes #355.