### PR TITLE
Add token scopes to TextRunProperties

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -109,9 +109,14 @@ namespace AvaloniaEdit.Demo
 
         private void Caret_PositionChanged(object sender, EventArgs e)
         {
-            _statusTextBlock.Text = string.Format("Line {0} Column {1}",
+            var scopes = _textMateInstallation.EditorModel.GetTokenScopes(
+                _textEditor.TextArea.Caret.Line - 1,
+                _textEditor.TextArea.Caret.Column - 1);
+
+            _statusTextBlock.Text = string.Format("Line {0} Column {1}. Scopes: {2}",
                 _textEditor.TextArea.Caret.Line,
-                _textEditor.TextArea.Caret.Column);
+                _textEditor.TextArea.Caret.Column,
+                scopes.Count > 0 ? string.Join(", ", scopes) : "None");
         }
 
         protected override void OnClosed(EventArgs e)

--- a/src/AvaloniaEdit.TextMate/TextEditorModel.cs
+++ b/src/AvaloniaEdit.TextMate/TextEditorModel.cs
@@ -1,10 +1,9 @@
 using System;
-
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Threading;
-
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Rendering;
-
 using TextMateSharp.Model;
 
 namespace AvaloniaEdit.TextMate
@@ -71,6 +70,19 @@ namespace AvaloniaEdit.TextMate
         public override int GetLineLength(int lineIndex)
         {
             return _documentSnapshot.GetLineLength(lineIndex);
+        }
+
+        public IReadOnlyCollection<string> GetTokenScopes(int lineIndex, int columnIndex)
+        {
+            var line = Get(lineIndex);
+            if (line == null) return Array.Empty<string>();
+
+            var element = line
+                .Tokens
+                .OrderBy(x => x.StartIndex)
+                .LastOrDefault(x => x.StartIndex <= columnIndex);
+
+            return element?.Scopes ?? new List<string>();
         }
 
         private void TextView_ScrollOffsetChanged(object sender, EventArgs e)


### PR DESCRIPTION
Hey, I didn't find how to get token scopes in editor. So there is an idea (;

During text decorating with `TextTransformation`, we already have token information here. So, we only need to include details to element `TextRunProperties` which we can read later whenever we need.

I didn't add any special method to read scopes, I use existing element properties:
```c#
private void Caret_PositionChanged(object sender, EventArgs e)
{
    var scopes = _textMateInstallation.EditorModel.GetTokenScopes(
        _textEditor.TextArea.Caret.Line - 1,
        _textEditor.TextArea.Caret.Column - 1);

    _statusTextBlock.Text = string.Format("Line {0} Column {1}. Scopes: {2}",
        _textEditor.TextArea.Caret.Line,
        _textEditor.TextArea.Caret.Column,
        scopes.Count > 0 ? string.Join(", ", scopes) : "None");
}
```

![image](https://github.com/AvaloniaUI/AvaloniaEdit/assets/1754265/0c405b96-9db6-4df1-a822-6c6cad49a6aa)
