### PR TITLE
Enable overstrike mode

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -59,6 +59,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.Background = this.Background;
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;
+            _textEditor.Options.AllowToggleOverstrikeMode = true;
             _textEditor.Options.ShowBoxForControlCharacters = true;
             _textEditor.Options.ColumnRulerPositions = new List<int>() { 80, 100 };
             _textEditor.TextArea.IndentationStrategy = new Indentation.CSharp.CSharpIndentationStrategy(_textEditor.Options);

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -854,9 +854,9 @@ namespace AvaloniaEdit.Editing
                     ReplaceSelectionWithNewLine();
                 else
                 {
-                    // TODO
-                    //if (OverstrikeMode && Selection.IsEmpty && Document.GetLineByNumber(Caret.Line).EndOffset > Caret.Offset)
-                    //    EditingCommands.SelectRightByCharacter.Execute(null, this);
+                    if (OverstrikeMode && Selection.IsEmpty && Document.GetLineByNumber(Caret.Line).EndOffset > Caret.Offset)
+                        EditingCommands.SelectRightByCharacter.Execute(null, this);
+
                     ReplaceSelectionWithText(e.Text);
                 }
                 OnTextEntered(e);


### PR DESCRIPTION
This PR enables *Overstrike* mode (in other editors called *OVR, Overwrite, Overtype*), which is not yet working.

Simply uncommenting the code in *TextArea.cs* solves the problem. All relevant code paths for Overstrike from AvalonEdit are already present in AvaloniaEdit.

Instruction for testing:
- Run *AvaloniaEdit.Demo*.
- Press `Insert` (`ins`) key on the keyboard.

Expected behavior:
- The caret changes from a line to block.
- Typing now overwrites the right characters instead of inserting characters at the caret position.
