### PR TITLE
Add custom, clickable margin in demo

### DIFF
--- a/src/AvaloniaEdit.Demo/CustomMargin.cs
+++ b/src/AvaloniaEdit.Demo/CustomMargin.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using AvaloniaEdit.Editing;
+using AvaloniaEdit.Rendering;
+
+#nullable enable
+
+namespace AvaloniaEdit.Demo
+{
+    /// <summary>
+    /// A custom, clickable margin.
+    /// </summary>
+    internal sealed class CustomMargin : AbstractMargin
+    {
+        private readonly IBrush _backgroundBrush = new ImmutableSolidColorBrush(Colors.DarkGray, 0.5f);
+        private readonly IBrush _pointerOverBrush = new ImmutableSolidColorBrush(new Color(192, 80, 80, 80));
+        private readonly IPen _pointerOverPen = new ImmutablePen(new ImmutableSolidColorBrush(new Color(192, 37, 37, 37)), 1);
+        private readonly IBrush _markerBrush = new ImmutableSolidColorBrush(new Color(192, 196, 65, 74));
+        private readonly IPen _markerPen = new ImmutablePen(new ImmutableSolidColorBrush(new Color(192, 186, 17, 28)), 1);
+
+        private readonly List<int> _markedDocumentLines = [];
+        private int _pointerOverLine = -1;
+
+        public CustomMargin()
+        {
+            Cursor = new Cursor(StandardCursorType.Arrow);
+        }
+
+        protected override void OnTextViewChanged(TextView? oldTextView, TextView? newTextView)
+        {
+            if (oldTextView != null)
+                oldTextView.VisualLinesChanged -= OnVisualLinesChanged;
+            if (newTextView != null)
+                newTextView.VisualLinesChanged += OnVisualLinesChanged;
+
+            base.OnTextViewChanged(oldTextView, newTextView);
+        }
+
+        private void OnVisualLinesChanged(object? sender, EventArgs eventArgs)
+        {
+            InvalidateVisual();
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            return new Size(20, 0);
+        }
+
+        private int GetLineNumber(PointerEventArgs e)
+        {
+            double visualY = e.GetPosition(TextView).Y + TextView.VerticalOffset;
+            VisualLine visualLine = TextView.GetVisualLineFromVisualTop(visualY);
+            return visualLine.FirstDocumentLine.LineNumber;
+        }
+
+        protected override void OnPointerMoved(PointerEventArgs e)
+        {
+            _pointerOverLine = GetLineNumber(e);
+            InvalidateVisual();
+
+            base.OnPointerMoved(e);
+        }
+
+        protected override void OnPointerExited(PointerEventArgs e)
+        {
+            _pointerOverLine = -1;
+
+            base.OnPointerExited(e);
+        }
+
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            int line = _pointerOverLine = GetLineNumber(e);
+
+            if (!_markedDocumentLines.Remove(line))
+                _markedDocumentLines.Add(line);
+
+            _markedDocumentLines.Sort();
+            InvalidateVisual();
+            e.Handled = true;
+
+            base.OnPointerPressed(e);
+        }
+
+        public override void Render(DrawingContext context)
+        {
+            context.DrawRectangle(_backgroundBrush, null, Bounds);
+
+            if (TextView?.VisualLinesValid == true)
+            {
+                foreach (var visualLine in TextView.VisualLines)
+                {
+                    double y = TextView.VerticalOffset + visualLine.VisualTop + visualLine.Height / 2;
+
+                    if (_pointerOverLine == visualLine.FirstDocumentLine.LineNumber)
+                        context.DrawEllipse(_pointerOverBrush, _pointerOverPen, new Point(10, y), 8, 8);
+                    else if (_markedDocumentLines.Contains(visualLine.FirstDocumentLine.LineNumber))
+                        context.DrawEllipse(_markerBrush, _markerPen, new Point(10, y), 8, 8);
+                }
+            }
+
+            base.Render(context);
+        }
+    }
+}

--- a/src/AvaloniaEdit.Demo/CustomMargin.cs
+++ b/src/AvaloniaEdit.Demo/CustomMargin.cs
@@ -12,15 +12,16 @@ using AvaloniaEdit.Rendering;
 namespace AvaloniaEdit.Demo
 {
     /// <summary>
-    /// A custom, clickable margin.
+    /// A custom margin that draws a red dot when clicked. (Similar to the breakpoint margin the
+    /// Visual Studio editor.)
     /// </summary>
     internal sealed class CustomMargin : AbstractMargin
     {
-        private readonly IBrush _backgroundBrush = new ImmutableSolidColorBrush(Colors.DarkGray, 0.5f);
+        private readonly IBrush _backgroundBrush = new ImmutableSolidColorBrush(new Color(255, 51, 51, 51));
         private readonly IBrush _pointerOverBrush = new ImmutableSolidColorBrush(new Color(192, 80, 80, 80));
         private readonly IPen _pointerOverPen = new ImmutablePen(new ImmutableSolidColorBrush(new Color(192, 37, 37, 37)), 1);
-        private readonly IBrush _markerBrush = new ImmutableSolidColorBrush(new Color(192, 196, 65, 74));
-        private readonly IPen _markerPen = new ImmutablePen(new ImmutableSolidColorBrush(new Color(192, 186, 17, 28)), 1);
+        private readonly IBrush _markerBrush = new ImmutableSolidColorBrush(new Color(255, 195, 81, 92));
+        private readonly IPen _markerPen = new ImmutablePen(new ImmutableSolidColorBrush(new Color(255, 240, 92, 104)), 1);
 
         private readonly List<int> _markedDocumentLines = [];
         private int _pointerOverLine = -1;

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -105,6 +105,9 @@ namespace AvaloniaEdit.Demo
                 if (i.Delta.Y > 0) _textEditor.FontSize++;
                 else _textEditor.FontSize = _textEditor.FontSize > 1 ? _textEditor.FontSize - 1 : 1;
             }, RoutingStrategies.Bubble, true);
+
+            // Add a custom margin at the left of the text area, which can be clicked.
+            _textEditor.TextArea.LeftMargins.Insert(0, new CustomMargin());
         }
 
         private void Caret_PositionChanged(object sender, EventArgs e)


### PR DESCRIPTION
This PR adds a custom margin to the text editor demo. It behaves like the *breakpoint margin* in Visual Studio. A gray circle is rendered when the mouse is over the margin and a red circle is rendered when the margin is clicked.

Screenshot:
![image](https://github.com/AvaloniaUI/AvaloniaEdit/assets/8617071/95c4e07b-62df-4069-aef7-62d798c9e598)