### PR TITLE
fix: Compile Issue

### DIFF
--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -175,7 +175,7 @@ namespace AvaloniaEdit.TextMate
                         background = themeRule.background;
 
                     if (fontStyle == 0 && themeRule.fontStyle > 0)
-                        fontStyle = (int)themeRule.fontStyle;
+                        fontStyle = themeRule.fontStyle;
                 }
 
                 if (transformations[i] == null)

--- a/src/AvaloniaEdit.TextMate/TextTransformation.cs
+++ b/src/AvaloniaEdit.TextMate/TextTransformation.cs
@@ -57,8 +57,8 @@ namespace AvaloniaEdit.TextMate
 
         AM.FontStyle GetFontStyle()
         {
-            if (FontStyle != (int)TextMateSharp.Themes.FontStyle.NotSet &&
-                (FontStyle & (int)TextMateSharp.Themes.FontStyle.Italic) != 0)
+            if (FontStyle != TextMateSharp.Themes.FontStyle.NotSet &&
+                (FontStyle & TextMateSharp.Themes.FontStyle.Italic) != 0)
                 return AM.FontStyle.Italic;
 
             return AM.FontStyle.Normal;
@@ -66,8 +66,8 @@ namespace AvaloniaEdit.TextMate
 
         AM.FontWeight GetFontWeight()
         {
-            if (FontStyle != (int)TextMateSharp.Themes.FontStyle.NotSet &&
-                (FontStyle & (int)TextMateSharp.Themes.FontStyle.Bold) != 0)
+            if (FontStyle != TextMateSharp.Themes.FontStyle.NotSet &&
+                (FontStyle & TextMateSharp.Themes.FontStyle.Bold) != 0)
                 return AM.FontWeight.Bold;
 
             return AM.FontWeight.Regular;
@@ -75,8 +75,8 @@ namespace AvaloniaEdit.TextMate
 
         bool IsUnderline()
         {
-            if (FontStyle != (int)TextMateSharp.Themes.FontStyle.NotSet &&
-                (FontStyle & (int)TextMateSharp.Themes.FontStyle.Underline) != 0)
+            if (FontStyle != TextMateSharp.Themes.FontStyle.NotSet &&
+                (FontStyle & TextMateSharp.Themes.FontStyle.Underline) != 0)
                 return true;
 
             return false;


### PR DESCRIPTION
- CS0266 Cannot implicitly convert type 'int' to 'TextMateSharp.Themes.FontStyle'
- CS0019 Operator '!=' cannot be applied to operands of type 'FontStyle' and 'int'
- CS0019 Operator '&' cannot be applied to operands of type 'FontStyle' and 'int'