### PR TITLE
Bump TextMateSharp version

### DIFF
--- a/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
+++ b/src/AvaloniaEdit.TextMate/AvaloniaEdit.TextMate.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="TextMateSharp" Version="1.0.58" />
-    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.58" />
+    <PackageReference Include="TextMateSharp" Version="1.0.59" />
+    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.59" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps TextMateSharp version to latest, which allows usage of changes from https://github.com/danipen/TextMateSharp/pull/67