### PR TITLE
Mouse ContextFlyout commands fix in AvaloniaEdit.Demo

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml
@@ -51,6 +51,16 @@
                                HorizontalScrollBarVisibility="Auto"
                                VerticalScrollBarVisibility="Visible"
                                FontWeight="Light"
-                               FontSize="14" />
+                               FontSize="14" >
+        <AvalonEdit:TextEditor.ContextFlyout>
+            <MenuFlyout>
+                <MenuItem Header="Copy" InputGesture="ctrl+C" Command="{Binding CopyMouseCommmand}" CommandParameter="{Binding #Editor.TextArea}"></MenuItem>
+                <MenuItem Header="Cut" InputGesture="ctrl+X" Command="{Binding CutMouseCommand}" CommandParameter="{Binding #Editor.TextArea}"></MenuItem>
+                <MenuItem Header="Paste" InputGesture="ctrl+V" Command="{Binding PasteMouseCommmand}"  CommandParameter="{Binding #Editor.TextArea}"></MenuItem>
+                <MenuItem Header="-"/>
+                <MenuItem Header="Select All" InputGesture="ctrl+A" Command="{Binding SelectAllMouseCommmand}" CommandParameter="{Binding #Editor.TextArea}"></MenuItem>
+            </MenuFlyout>
+        </AvalonEdit:TextEditor.ContextFlyout>
+        </AvalonEdit:TextEditor>
     </DockPanel>
 </Window>

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -51,7 +51,8 @@ namespace AvaloniaEdit.Demo
             _textEditor.HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Visible;
             _textEditor.Background = Brushes.Transparent;
             _textEditor.ShowLineNumbers = true;
-            _textEditor.ContextMenu = new ContextMenu
+            // The ContextMenu has been defined in MainWindow.xaml 
+            /*_textEditor.ContextMenu = new ContextMenu
             {
                 ItemsSource = new List<MenuItem>
                 {
@@ -59,7 +60,7 @@ namespace AvaloniaEdit.Demo
                     new MenuItem { Header = "Paste", InputGesture = new KeyGesture(Key.V, KeyModifiers.Control) },
                     new MenuItem { Header = "Cut", InputGesture = new KeyGesture(Key.X, KeyModifiers.Control) }
                 }
-            };
+            };*/
             _textEditor.TextArea.Background = this.Background;
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -51,16 +51,6 @@ namespace AvaloniaEdit.Demo
             _textEditor.HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Visible;
             _textEditor.Background = Brushes.Transparent;
             _textEditor.ShowLineNumbers = true;
-            // The ContextMenu has been defined in MainWindow.xaml 
-            /*_textEditor.ContextMenu = new ContextMenu
-            {
-                ItemsSource = new List<MenuItem>
-                {
-                    new MenuItem { Header = "Copy", InputGesture = new KeyGesture(Key.C, KeyModifiers.Control) },
-                    new MenuItem { Header = "Paste", InputGesture = new KeyGesture(Key.V, KeyModifiers.Control) },
-                    new MenuItem { Header = "Cut", InputGesture = new KeyGesture(Key.X, KeyModifiers.Control) }
-                }
-            };*/
             _textEditor.TextArea.Background = this.Background;
             _textEditor.TextArea.TextEntered += textEditor_TextArea_TextEntered;
             _textEditor.TextArea.TextEntering += textEditor_TextArea_TextEntering;

--- a/src/AvaloniaEdit.Demo/ViewModels/MainWIndowViewModel.cs
+++ b/src/AvaloniaEdit.Demo/ViewModels/MainWIndowViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using AvaloniaEdit.Editing;
 using ReactiveUI;
 using TextMateSharp.Grammars;
 
@@ -17,5 +18,31 @@ public class MainWindowViewModel(TextMate.TextMate.Installation _textMateInstall
             this.RaiseAndSetIfChanged(ref _selectedTheme, value);
             _textMateInstallation.SetTheme(_registryOptions.LoadTheme(value.ThemeName));
         }
+    }
+
+    public void CopyMouseCommmand(TextArea textArea)
+    {
+        ApplicationCommands.Copy.Execute(null, textArea);
+    }
+
+    public void CutMouseCommand(TextArea textArea)
+    {
+        ApplicationCommands.Cut.Execute(null, textArea);
+    }
+    
+    public void PasteMouseCommmand(TextArea textArea)
+    {
+        ApplicationCommands.Paste.Execute(null, textArea);
+    }
+
+    public void SelectAllMouseCommmand(TextArea textArea)
+    {
+        ApplicationCommands.SelectAll.Execute(null, textArea);
+    }
+
+    // Undo Status is not given back to disable it's item in ContextFlyout; therefore it's not being used yet.
+    public void UndoMouseCommmand(TextArea textArea)
+    {
+        ApplicationCommands.Undo.Execute(null, textArea);
     }
 }


### PR DESCRIPTION
hello 

this is a PR fixing Commands of Mouse ContextMenu for AvaloniaEdit.Demo

used ContextFlyout instead of ContextMenu
previous actions which were not working:

![Screenshot 2024-08-05 123041](https://github.com/user-attachments/assets/4d24d0ae-9518-4891-84eb-1189336c95d2)


now these Items working (it's not ReactiveUI, basic MVVM):


![Screenshot 2024-08-05 124512](https://github.com/user-attachments/assets/7b0b3164-741f-4f28-8967-dc5b622ab73b)

couldn't find a better way to call the Commands from Demo. but this seems working just fine .in that case let me know here,

PS:   it's my very first PR 😅, hope it helps and more importantly hope i've done it the right way
