### PR TITLE
Do not run the element generators for performance reasons

### DIFF
--- a/src/AvaloniaEdit/Rendering/VisualLine.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLine.cs
@@ -166,6 +166,13 @@ namespace AvaloniaEdit.Rendering
             LastDocumentLine = FirstDocumentLine;
             var askInterestOffset = 0; // 0 or 1
 
+            // for long lines, do not run the element generators for performance reasons
+            if (lineLength > LENGTH_LIMIT)
+            {
+                _elements.Add(new VisualLineText(this, lineLength));
+                return;
+            }
+
             while (offset + askInterestOffset <= currentLineEnd)
             {
                 var textPieceEndOffset = currentLineEnd;


### PR DESCRIPTION
Having documents with very long lines, 1M columns or so (this can happen for minified json or javascript) caused the UI to stop running.