### PR TITLE
Add option to insert completion item on PointerPressed/PointerReleased/DoubleTapped

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace AvaloniaEdit.Demo
             _textEditor.TextArea.Caret.PositionChanged += Caret_PositionChanged;
             _textEditor.TextArea.RightClickMovesCaret = true;
             _textEditor.Options.HighlightCurrentLine = true;
+            _textEditor.Options.CompletionAcceptAction = CompletionAcceptAction.DoubleTapped;
 
             _addControlButton = this.FindControl<Button>("addControlBtn");
             _addControlButton.Click += AddControlButton_Click;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionAcceptAction.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionAcceptAction.cs
@@ -1,0 +1,25 @@
+﻿namespace AvaloniaEdit.CodeCompletion;
+
+/// <summary>
+/// Defines the pointer action used to request the insertion of a completion item.
+/// </summary>
+public enum CompletionAcceptAction
+{
+    /// <summary>
+    /// Insert the completion item when the pointer is pressed. (This option makes the completion
+    /// list behave similar to the completion list in Visual Studio Code.)
+    /// </summary>
+    PointerPressed,
+
+    /// <summary>
+    /// Insert the completion item when the pointer is pressed. (This option makes the completion
+    /// list behave similar to a context menu.)
+    /// </summary>
+    PointerReleased,
+
+    /// <summary>
+    /// Insert the code completion item when the item is double-tapped. (This option makes the
+    /// completion list behave similar to the completion list in Visual Studio.)
+    /// </summary>
+    DoubleTapped
+}

--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
@@ -21,9 +21,7 @@ using Avalonia;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Editing;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
 using Avalonia.Input;
-using Avalonia.Media;
 
 namespace AvaloniaEdit.CodeCompletion
 {
@@ -45,7 +43,11 @@ namespace AvaloniaEdit.CodeCompletion
         /// </summary>
         public CompletionWindow(TextArea textArea) : base(textArea)
         {
-            CompletionList = new CompletionList();
+            CompletionList = new CompletionList
+            {
+                CompletionAcceptAction = textArea.Options.CompletionAcceptAction
+            };
+
             // keep height automatic
             CloseAutomatically = true;
             MaxHeight = 225;
@@ -59,7 +61,10 @@ namespace AvaloniaEdit.CodeCompletion
 
             _toolTip = new PopupWithCustomPosition
             {
-                IsLightDismissEnabled = true,
+                // The popup should not interfere with the pointer input. Popup visibility is
+                // controlled explicitly.
+                IsLightDismissEnabled = false,
+
                 PlacementTarget = this,
                 Child = _toolTipContent,
             };

--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindowBase.cs
@@ -260,7 +260,6 @@ namespace AvaloniaEdit.CodeCompletion
             UpdatePosition();
         }
 
-        /// <inheritdoc/>
         private void OnDeactivated(object sender, EventArgs e)
         {
             Dispatcher.UIThread.Post(CloseIfFocusLost, DispatcherPriority.Background);

--- a/src/AvaloniaEdit/TextEditorOptions.cs
+++ b/src/AvaloniaEdit/TextEditorOptions.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using AvaloniaEdit.CodeCompletion;
 
 namespace AvaloniaEdit
 {
@@ -696,6 +697,25 @@ namespace AvaloniaEdit
                 {
                     _extendSelectionOnMouseUp = value;
                     OnPropertyChanged(nameof(ExtendSelectionOnMouseUp));
+                }
+            }
+        }
+
+        private CompletionAcceptAction _completionAcceptAction = CompletionAcceptAction.PointerPressed;
+
+        /// <summary>
+        /// Gets/Sets the pointer action used to request the insertion of a completion item.
+        /// </summary>
+        [DefaultValue(CompletionAcceptAction.PointerPressed)]
+        public CompletionAcceptAction CompletionAcceptAction
+        {
+            get { return _completionAcceptAction; }
+            set
+            {
+                if (_completionAcceptAction != value)
+                {
+                    _completionAcceptAction = value;
+                    OnPropertyChanged(nameof(CompletionAcceptAction));
                 }
             }
         }


### PR DESCRIPTION
This PR adds an options to choose whether completion items are inserted on `PointerPressed`, `PointerReleased` or `DoubleTapped`.

This is an improvement on #414 and addresses the feedback by @gebodal mentioned on issue #413.

In addition, this fixes an issue where first click in the `CompletionWindow` is swallowed by the `PopupWithCustomPosition` tooltip.