### PR TITLE
Completion window improvements

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -304,20 +304,13 @@ namespace AvaloniaEdit.Demo
                 _completionWindow.Closed += (o, args) => _completionWindow = null;
 
                 var data = _completionWindow.CompletionList.CompletionData;
-                data.Add(new MyCompletionData("Item1"));
-                data.Add(new MyCompletionData("Item2"));
-                data.Add(new MyCompletionData("Item3"));
-                data.Add(new MyCompletionData("Item4"));
-                data.Add(new MyCompletionData("Item5"));
-                data.Add(new MyCompletionData("Item6"));
-                data.Add(new MyCompletionData("Item7"));
-                data.Add(new MyCompletionData("Item8"));
-                data.Add(new MyCompletionData("Item9"));
-                data.Add(new MyCompletionData("Item10"));
-                data.Add(new MyCompletionData("Item11"));
-                data.Add(new MyCompletionData("Item12"));
-                data.Add(new MyCompletionData("Item13"));
 
+                for (int i = 0; i < 500; i++)
+                {
+                    data.Add(new MyCompletionData("Item" + i.ToString()));
+                }
+
+                data.Insert(20, new MyCompletionData("long item to demosntrate dynamic poup resizing"));
 
                 _completionWindow.Show();
             }
@@ -443,7 +436,7 @@ namespace AvaloniaEdit.Demo
             public string Text { get; }
 
             // Use this property if you want to show a fancy UIElement in the list.
-            public object Content => Text;
+            public object Content => _contentControl ??= BuildContentControl();
 
             public object Description => "Description for " + Text;
 
@@ -454,6 +447,17 @@ namespace AvaloniaEdit.Demo
             {
                 textArea.Document.Replace(completionSegment, Text);
             }
+
+            Control BuildContentControl()
+            {
+                TextBlock textBlock = new TextBlock();
+                textBlock.Text = Text;
+                textBlock.Margin = new Thickness(5);
+
+                return textBlock;
+            }
+
+            Control _contentControl;
         }
 
         class ElementGenerator : VisualLineElementGenerator, IComparer<Pair>

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -27,6 +27,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml.Templates;
+using Avalonia.Threading;
 using AvaloniaEdit.Utils;
 
 namespace AvaloniaEdit.CodeCompletion
@@ -321,7 +322,7 @@ namespace AvaloniaEdit.CodeCompletion
             _currentList = listBoxItems;
             //_listBox.Items = null; Makes no sense? Tooltip disappeared because of this
             _listBox.ItemsSource = listBoxItems;
-            SelectIndexCentered(bestIndex);
+            Dispatcher.UIThread.Post(() => { SelectIndexCentered(bestIndex); }, DispatcherPriority.Loaded);
         }
 
         /// <summary>

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -154,10 +154,15 @@ namespace AvaloniaEdit.CodeCompletion
                 case Key.Down:
                     e.Handled = true;
                     _listBox.SelectIndex(_listBox.SelectedIndex + 1);
+                    _listBox.SelectIndex(
+                        (_listBox.SelectedIndex + 1) % _listBox.Items.Count);
                     break;
                 case Key.Up:
                     e.Handled = true;
                     _listBox.SelectIndex(_listBox.SelectedIndex - 1);
+                    _listBox.SelectIndex((_listBox.SelectedIndex == 0)
+                        ? _listBox.Items.Count - 1
+                        : _listBox.SelectedIndex - 1);
                     break;
                 case Key.PageDown:
                     e.Handled = true;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -147,6 +147,9 @@ namespace AvaloniaEdit.CodeCompletion
             if (_listBox == null)
                 return;
 
+            if (_listBox.Items.Count == 0)
+                return;
+
             // We have to do some key handling manually, because the default doesn't work with
             // our simulated events.
             // Also, the default PageUp/PageDown implementation changes the focus, so we avoid it.
@@ -154,8 +157,7 @@ namespace AvaloniaEdit.CodeCompletion
             {
                 case Key.Down:
                     e.Handled = true;
-                    if (_listBox.Items.Count > 0)
-                        _listBox.SelectIndex((_listBox.SelectedIndex + 1) % _listBox.Items.Count);
+                    _listBox.SelectIndex((_listBox.SelectedIndex + 1) % _listBox.Items.Count);
                     break;
                 case Key.Up:
                     e.Handled = true;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -154,7 +154,8 @@ namespace AvaloniaEdit.CodeCompletion
             {
                 case Key.Down:
                     e.Handled = true;
-                    _listBox.SelectIndex((_listBox.SelectedIndex + 1) % _listBox.Items.Count);
+                    if (_listBox.Items.Count > 0)
+                        _listBox.SelectIndex((_listBox.SelectedIndex + 1) % _listBox.Items.Count);
                     break;
                 case Key.Up:
                     e.Handled = true;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -120,7 +120,7 @@ namespace AvaloniaEdit.CodeCompletion
         /// </summary>
         public ScrollViewer ScrollViewer => _listBox?.ScrollViewer;
 
-        private readonly ObservableCollection<ICompletionData> _completionData = new ObservableCollection<ICompletionData>();
+        private readonly List<ICompletionData> _completionData = new List<ICompletionData>();
 
         /// <summary>
         /// Gets the list to which completion data can be added.
@@ -252,7 +252,7 @@ namespace AvaloniaEdit.CodeCompletion
         // SelectItem gets called twice for every typed character (once from FormatLine), this helps execute SelectItem only once
         private string _currentText;
 
-        private ObservableCollection<ICompletionData> _currentList;
+        private List<ICompletionData> _currentList;
 
         public List<ICompletionData> CurrentList
         {
@@ -299,7 +299,7 @@ namespace AvaloniaEdit.CodeCompletion
             // e.g. "DateTimeKind k = (*cc here suggests DateTimeKind*)"
             var suggestedItem = _listBox.SelectedIndex != -1 ? (ICompletionData)_listBox.SelectedItem : null;
 
-            var listBoxItems = new ObservableCollection<ICompletionData>();
+            var listBoxItems = new List<ICompletionData>();
             var bestIndex = -1;
             var bestQuality = -1;
             double bestPriority = 0;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -154,11 +154,11 @@ namespace AvaloniaEdit.CodeCompletion
             {
                 case Key.Down:
                     e.Handled = true;
-                    _listBox.SelectIndex(_listBox.SelectedIndex + 1);
+                    _listBox.SelectIndex((_listBox.SelectedIndex + 1) % _listBox.Items.Count);
                     break;
                 case Key.Up:
                     e.Handled = true;
-                    _listBox.SelectIndex((_listBox.SelectedIndex == 0)
+                    _listBox.SelectIndex(_listBox.SelectedIndex == 0
                         ? _listBox.Items.Count - 1
                         : _listBox.SelectedIndex - 1);
                     break;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionList.cs
@@ -155,12 +155,9 @@ namespace AvaloniaEdit.CodeCompletion
                 case Key.Down:
                     e.Handled = true;
                     _listBox.SelectIndex(_listBox.SelectedIndex + 1);
-                    _listBox.SelectIndex(
-                        (_listBox.SelectedIndex + 1) % _listBox.Items.Count);
                     break;
                 case Key.Up:
                     e.Handled = true;
-                    _listBox.SelectIndex(_listBox.SelectedIndex - 1);
                     _listBox.SelectIndex((_listBox.SelectedIndex == 0)
                         ? _listBox.Items.Count - 1
                         : _listBox.SelectedIndex - 1);

--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
@@ -49,11 +49,11 @@ namespace AvaloniaEdit.CodeCompletion
             // keep height automatic
             CloseAutomatically = true;
             MaxHeight = 225;
-            Width = 175;
+            MaxWidth = 550;
             Child = CompletionList;
             // prevent user from resizing window to 0x0
             MinHeight = 15;
-            MinWidth = 30;
+            MinWidth = 175;
 
             _toolTipContent = new CompletionTipContentControl();
 
@@ -143,10 +143,16 @@ namespace AvaloniaEdit.CodeCompletion
             item?.Complete(TextArea, new AnchorSegment(TextArea.Document, StartOffset, EndOffset - StartOffset), e);
         }
 
+        private void CompletionList_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            MinWidth = Math.Max(MinWidth, CompletionList.Bounds.Width);
+        }
+
         private void AttachEvents()
         {
             CompletionList.InsertionRequested += CompletionList_InsertionRequested;
             CompletionList.SelectionChanged += CompletionList_SelectionChanged;
+            CompletionList.SizeChanged += CompletionList_SizeChanged;
             TextArea.Caret.PositionChanged += CaretPositionChanged;
             TextArea.PointerWheelChanged += TextArea_MouseWheel;
             TextArea.TextInput += TextArea_PreviewTextInput;
@@ -157,6 +163,7 @@ namespace AvaloniaEdit.CodeCompletion
         {
             CompletionList.InsertionRequested -= CompletionList_InsertionRequested;
             CompletionList.SelectionChanged -= CompletionList_SelectionChanged;
+            CompletionList.SizeChanged -= CompletionList_SizeChanged;
             TextArea.Caret.PositionChanged -= CaretPositionChanged;
             TextArea.PointerWheelChanged -= TextArea_MouseWheel;
             TextArea.TextInput -= TextArea_PreviewTextInput;

--- a/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
+++ b/src/AvaloniaEdit/CodeCompletion/CompletionWindow.cs
@@ -229,8 +229,8 @@ namespace AvaloniaEdit.CodeCompletion
                 {
                     CompletionList.SelectItem(string.Empty);
 
-                    if (CompletionList.ListBox.ItemCount == 0) IsVisible = false;
-                    else IsVisible = true;
+                    if (CompletionList.ListBox.ItemCount == 0) CompletionList.IsVisible = false;
+                    else CompletionList.IsVisible = true;
                 }
                 return;
             }
@@ -248,8 +248,8 @@ namespace AvaloniaEdit.CodeCompletion
                 {
                     CompletionList.SelectItem(document.GetText(StartOffset, offset - StartOffset));
 
-                    if (CompletionList.ListBox.ItemCount == 0) IsVisible = false;
-                    else IsVisible = true;
+                    if (CompletionList.ListBox.ItemCount == 0) CompletionList.IsVisible = false;
+                    else CompletionList.IsVisible = true;
                 }
             }
         }


### PR DESCRIPTION
- Makes the CompletionList selection circular.
- Fixes a virtualization issue.
- Allows the completion window to grow dynamically (due to virtualization), constraining the MinWidth so once the popup gets wider, it never gets narrower again during that session.

Demo:


https://github.com/user-attachments/assets/b6b078be-6737-4b60-b7f4-475a16907b91


