### PR TITLE
Fixed NRE in custom margin

### DIFF
--- a/src/AvaloniaEdit.Demo/CustomMargin.cs
+++ b/src/AvaloniaEdit.Demo/CustomMargin.cs
@@ -86,7 +86,7 @@ namespace AvaloniaEdit.Demo
         {
             double visualY = e.GetPosition(TextView).Y + TextView.VerticalOffset;
             VisualLine visualLine = TextView.GetVisualLineFromVisualTop(visualY);
-            return visualLine.FirstDocumentLine.LineNumber;
+            return (visualLine == null) ? -1 : visualLine.FirstDocumentLine.LineNumber;
         }
 
         protected override void OnPointerMoved(PointerEventArgs e)


### PR DESCRIPTION
Protect NRE when you move the mouse near the edges and the VisualLine is null