### PR TITLE
Fixed BoxSelectionModifiers in macOS shadowing other keymaps

### DIFF
--- a/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
@@ -82,28 +82,29 @@ namespace AvaloniaEdit.Editing
 
         static CaretNavigationCommandHandler()
         {
-            var keymap = Application.Current.PlatformSettings.HotkeyConfiguration;
+            var keymap = HotkeyConfiguration.Keymap;
+            var boxSelectionModifiers = HotkeyConfiguration.BoxSelectionModifiers;
 
             AddBinding(EditingCommands.MoveLeftByCharacter, KeyModifiers.None, Key.Left, OnMoveCaret(CaretMovementType.CharLeft));
             AddBinding(EditingCommands.SelectLeftByCharacter, keymap.SelectionModifiers, Key.Left, OnMoveCaretExtendSelection(CaretMovementType.CharLeft));
-            AddBinding(RectangleSelection.BoxSelectLeftByCharacter, KeyModifiers.Alt | keymap.SelectionModifiers, Key.Left, OnMoveCaretBoxSelection(CaretMovementType.CharLeft));
+            AddBinding(RectangleSelection.BoxSelectLeftByCharacter, boxSelectionModifiers | keymap.SelectionModifiers, Key.Left, OnMoveCaretBoxSelection(CaretMovementType.CharLeft));
             AddBinding(EditingCommands.MoveRightByCharacter, KeyModifiers.None, Key.Right, OnMoveCaret(CaretMovementType.CharRight));
             AddBinding(EditingCommands.SelectRightByCharacter, keymap.SelectionModifiers, Key.Right, OnMoveCaretExtendSelection(CaretMovementType.CharRight));
-            AddBinding(RectangleSelection.BoxSelectRightByCharacter, KeyModifiers.Alt | keymap.SelectionModifiers, Key.Right, OnMoveCaretBoxSelection(CaretMovementType.CharRight));
+            AddBinding(RectangleSelection.BoxSelectRightByCharacter, boxSelectionModifiers | keymap.SelectionModifiers, Key.Right, OnMoveCaretBoxSelection(CaretMovementType.CharRight));
 
             AddBinding(EditingCommands.MoveLeftByWord, keymap.WholeWordTextActionModifiers, Key.Left, OnMoveCaret(CaretMovementType.WordLeft));
             AddBinding(EditingCommands.SelectLeftByWord, keymap.WholeWordTextActionModifiers | keymap.SelectionModifiers, Key.Left, OnMoveCaretExtendSelection(CaretMovementType.WordLeft));
-            AddBinding(RectangleSelection.BoxSelectLeftByWord, keymap.WholeWordTextActionModifiers | KeyModifiers.Alt | keymap.SelectionModifiers, Key.Left, OnMoveCaretBoxSelection(CaretMovementType.WordLeft));
+            AddBinding(RectangleSelection.BoxSelectLeftByWord, keymap.WholeWordTextActionModifiers | boxSelectionModifiers | keymap.SelectionModifiers, Key.Left, OnMoveCaretBoxSelection(CaretMovementType.WordLeft));
             AddBinding(EditingCommands.MoveRightByWord, keymap.WholeWordTextActionModifiers, Key.Right, OnMoveCaret(CaretMovementType.WordRight));
             AddBinding(EditingCommands.SelectRightByWord, keymap.WholeWordTextActionModifiers | keymap.SelectionModifiers, Key.Right, OnMoveCaretExtendSelection(CaretMovementType.WordRight));
-            AddBinding(RectangleSelection.BoxSelectRightByWord, keymap.WholeWordTextActionModifiers | KeyModifiers.Alt | keymap.SelectionModifiers, Key.Right, OnMoveCaretBoxSelection(CaretMovementType.WordRight));
+            AddBinding(RectangleSelection.BoxSelectRightByWord, keymap.WholeWordTextActionModifiers | boxSelectionModifiers | keymap.SelectionModifiers, Key.Right, OnMoveCaretBoxSelection(CaretMovementType.WordRight));
 
             AddBinding(EditingCommands.MoveUpByLine, KeyModifiers.None, Key.Up, OnMoveCaret(CaretMovementType.LineUp));
             AddBinding(EditingCommands.SelectUpByLine, keymap.SelectionModifiers, Key.Up, OnMoveCaretExtendSelection(CaretMovementType.LineUp));
-            AddBinding(RectangleSelection.BoxSelectUpByLine, KeyModifiers.Alt | keymap.SelectionModifiers, Key.Up, OnMoveCaretBoxSelection(CaretMovementType.LineUp));
+            AddBinding(RectangleSelection.BoxSelectUpByLine, boxSelectionModifiers | keymap.SelectionModifiers, Key.Up, OnMoveCaretBoxSelection(CaretMovementType.LineUp));
             AddBinding(EditingCommands.MoveDownByLine, KeyModifiers.None, Key.Down, OnMoveCaret(CaretMovementType.LineDown));
             AddBinding(EditingCommands.SelectDownByLine, keymap.SelectionModifiers, Key.Down, OnMoveCaretExtendSelection(CaretMovementType.LineDown));
-            AddBinding(RectangleSelection.BoxSelectDownByLine, KeyModifiers.Alt | keymap.SelectionModifiers, Key.Down, OnMoveCaretBoxSelection(CaretMovementType.LineDown));
+            AddBinding(RectangleSelection.BoxSelectDownByLine, boxSelectionModifiers | keymap.SelectionModifiers, Key.Down, OnMoveCaretBoxSelection(CaretMovementType.LineDown));
 
             AddBinding(EditingCommands.MoveDownByPage, KeyModifiers.None, Key.PageDown, OnMoveCaret(CaretMovementType.PageDown));
             AddBinding(EditingCommands.SelectDownByPage, keymap.SelectionModifiers, Key.PageDown, OnMoveCaretExtendSelection(CaretMovementType.PageDown));
@@ -119,8 +120,8 @@ namespace AvaloniaEdit.Editing
             foreach (var keyGesture in keymap.MoveCursorToTheEndOfLineWithSelection)
                 AddBinding(EditingCommands.SelectToLineEnd, keyGesture, OnMoveCaretExtendSelection(CaretMovementType.LineEnd));
 
-            AddBinding(RectangleSelection.BoxSelectToLineStart, KeyModifiers.Alt | keymap.SelectionModifiers, Key.Home, OnMoveCaretBoxSelection(CaretMovementType.LineStart));
-            AddBinding(RectangleSelection.BoxSelectToLineEnd, KeyModifiers.Alt | keymap.SelectionModifiers, Key.End, OnMoveCaretBoxSelection(CaretMovementType.LineEnd));
+            AddBinding(RectangleSelection.BoxSelectToLineStart, boxSelectionModifiers | keymap.SelectionModifiers, Key.Home, OnMoveCaretBoxSelection(CaretMovementType.LineStart));
+            AddBinding(RectangleSelection.BoxSelectToLineEnd, boxSelectionModifiers | keymap.SelectionModifiers, Key.End, OnMoveCaretBoxSelection(CaretMovementType.LineEnd));
 
             foreach (var keyGesture in keymap.MoveCursorToTheStartOfDocument)
                 AddBinding(EditingCommands.MoveToDocumentStart, keyGesture, OnMoveCaret(CaretMovementType.DocumentStart));

--- a/src/AvaloniaEdit/Editing/HotkeyConfiguration.cs
+++ b/src/AvaloniaEdit/Editing/HotkeyConfiguration.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+
+namespace AvaloniaEdit.Editing;
+
+public static class HotkeyConfiguration
+{
+    public static KeyModifiers BoxSelectionModifiers { get; private set; }
+
+    public static PlatformHotkeyConfiguration Keymap
+    {
+        get { return Application.Current.PlatformSettings.HotkeyConfiguration; }
+    }
+
+    static HotkeyConfiguration()
+    {
+        BoxSelectionModifiers = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                KeyModifiers.Control : KeyModifiers.Alt;
+    }
+}

--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -438,7 +438,7 @@ namespace AvaloniaEdit.Editing
 
                     if (TextArea.CapturePointer(e.Pointer))
                     {
-                        if (modifiers.HasFlag(KeyModifiers.Alt) && TextArea.Options.EnableRectangularSelection)
+                        if (modifiers.HasFlag(HotkeyConfiguration.BoxSelectionModifiers) && TextArea.Options.EnableRectangularSelection)
                         {
                             _mode = SelectionMode.Rectangular;
                             if (shift && TextArea.Selection is RectangleSelection)


### PR DESCRIPTION
Pressing `Shift+Option+Arrow keys` didn't work in macOS because rectangular selection shadowed this keystroke combination (we were using Alt, which is equivalent to Option for rectangular selection on all platforms).

Now we use Control in the macOS platform for the rectangular selection so every command works as expected:
* `Shift+Option+Left/Right` now selects the next previous word.
* `Shift+Control+Up/Down` performs rectangular selection.
* `Control+Mouse selection` performs a rectangular selection with the mouse.

https://github.com/user-attachments/assets/7b878bf8-b346-45cd-8269-85fdaefc0fb3

