### PR TITLE
Update regex to support emails with +1, +2 ...

### DIFF
--- a/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/LinkElementGenerator.cs
@@ -37,7 +37,7 @@ namespace AvaloniaEdit.Rendering
 		internal readonly static Regex DefaultLinkRegex = new Regex(@"\b(https?://|ftp://|www\.)[\w\d\._/\-~%@()+:?&=#!]*[\w\d/]");
 
 		// try to detect email addresses
-		internal readonly static Regex DefaultMailRegex = new Regex(@"\b[\w\d\.\-]+\@[\w\d\.\-]+\.[a-z]{2,6}\b");
+		internal readonly static Regex DefaultMailRegex = new Regex(@"\b[\w\d\.\-\+]+\@[\w\d\.\-]+\.[a-z]{2,6}\b");
 
 		private readonly Regex _linkRegex;
 


### PR DESCRIPTION
Emails like `example+1@domain.com` were not properly recognized.