### PR TITLE
Added AcceptsTab option to TextEditor

### DIFF
--- a/src/AvaloniaEdit.Demo/AvaloniaEdit.Demo.csproj
+++ b/src/AvaloniaEdit.Demo/AvaloniaEdit.Demo.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Avalonia" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSampleVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSampleVersion)"/>
+    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaSampleVersion)"/>
     <PackageReference Include="ReactiveUI" Version="20.1.1" />
     <ProjectReference Include="..\AvaloniaEdit\AvaloniaEdit.csproj" />
     <ProjectReference Include="..\AvaloniaEdit.TextMate\AvaloniaEdit.TextMate.csproj" />

--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -47,6 +47,8 @@ namespace AvaloniaEdit.Demo
         {
             InitializeComponent();
 
+            this.AttachDevTools();
+
             _textEditor = this.FindControl<TextEditor>("Editor");
             _textEditor.HorizontalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Visible;
             _textEditor.Background = Brushes.Transparent;

--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -25,6 +25,7 @@ using AvaloniaEdit.Document;
 using Avalonia.Input;
 using AvaloniaEdit.Utils;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace AvaloniaEdit.Editing
 {
@@ -73,8 +74,6 @@ namespace AvaloniaEdit.Editing
                 OnDelete(CaretMovementType.WordLeft));
             AddBinding(EditingCommands.EnterParagraphBreak, KeyModifiers.None, Key.Enter, OnEnter);
             AddBinding(EditingCommands.EnterLineBreak, KeyModifiers.Shift, Key.Enter, OnEnter);
-            AddBinding(EditingCommands.TabForward, KeyModifiers.None, Key.Tab, OnTab);
-            AddBinding(EditingCommands.TabBackward, KeyModifiers.Shift, Key.Tab, OnShiftTab);
 
             AddBinding(ApplicationCommands.Delete, OnDelete(CaretMovementType.None), CanDelete);
             AddBinding(ApplicationCommands.Copy, OnCopy, CanCopy);
@@ -115,7 +114,7 @@ namespace AvaloniaEdit.Editing
         /// transformLine needs to handle read-only segments!
         /// </summary>
         private static void TransformSelectedLines(Action<TextArea, DocumentLine> transformLine, object target,
-            ExecutedRoutedEventArgs args, DefaultSegmentType defaultSegmentType)
+            RoutedEventArgs args, DefaultSegmentType defaultSegmentType)
         {
             var textArea = GetTextArea(target);
             if (textArea?.Document != null)
@@ -228,7 +227,7 @@ namespace AvaloniaEdit.Editing
 
         #region Tab
 
-        private static void OnTab(object target, ExecutedRoutedEventArgs args)
+        public static void OnTab(object target, RoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
             if (textArea?.Document != null)
@@ -264,9 +263,11 @@ namespace AvaloniaEdit.Editing
                 textArea.Caret.BringCaretToView();
                 args.Handled = true;
             }
+
+            TextBox textBox = new TextBox();
         }
 
-        private static void OnShiftTab(object target, ExecutedRoutedEventArgs args)
+        public static void OnShiftTab(object target, RoutedEventArgs args)
         {
             TransformSelectedLines(
                 delegate (TextArea textArea, DocumentLine line)

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -958,10 +958,11 @@ namespace AvaloniaEdit.Editing
                 if (e.KeyModifiers == KeyModifiers.Shift)
                 {
                     EditingCommandHandler.OnShiftTab(this, e);
-                    return;
                 }
-
-                EditingCommandHandler.OnTab(this, e);
+                else
+                {
+                    EditingCommandHandler.OnTab(this, e);
+                }
             }
 
             TextView.InvalidateCursorIfPointerWithinTextView();

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -951,6 +951,19 @@ namespace AvaloniaEdit.Editing
         protected override void OnKeyDown(KeyEventArgs e)
         {
             base.OnKeyDown(e);
+
+            if (e.Key == Key.Tab && Options.AcceptsTab)
+            {
+                e.Handled = true;
+                if (e.KeyModifiers == KeyModifiers.Shift)
+                {
+                    EditingCommandHandler.OnShiftTab(this, e);
+                    return;
+                }
+
+                EditingCommandHandler.OnTab(this, e);
+            }
+
             TextView.InvalidateCursorIfPointerWithinTextView();
         }
 

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -48,7 +48,7 @@ namespace AvaloniaEdit
         #region Constructors
         static TextEditor()
         {
-            FocusableProperty.OverrideDefaultValue<TextEditor>(true);
+            FocusableProperty.OverrideDefaultValue<TextEditor>(false);
             HorizontalScrollBarVisibilityProperty.OverrideDefaultValue<TextEditor>(ScrollBarVisibility.Auto);
             VerticalScrollBarVisibilityProperty.OverrideDefaultValue<TextEditor>(ScrollBarVisibility.Auto);
 

--- a/src/AvaloniaEdit/TextEditorOptions.cs
+++ b/src/AvaloniaEdit/TextEditorOptions.cs
@@ -77,6 +77,28 @@ namespace AvaloniaEdit
         }
         #endregion
 
+        #region AccepsTab
+
+        bool _acceptsTab = true;
+        [DefaultValue(true)]
+        public virtual bool AcceptsTab
+        {
+            get
+            {
+                return _acceptsTab;
+            }
+            set
+            {
+                if (_acceptsTab != value)
+                {
+                    _acceptsTab = value;
+                    OnPropertyChanged(nameof(AcceptsTab));
+                }
+            }
+        }
+
+        #endregion
+
         #region ShowSpaces / ShowTabs / ShowEndOfLine / ShowBoxForControlCharacters
 
         private bool _showSpaces;


### PR DESCRIPTION
This PR introduces a new option, `AcceptsTab`, similar to [Avalonia's TextBox.AcceptsTab](https://github.com/AvaloniaUI/Avalonia/blob/9cecb90ba1e681d1783e3a89db4b8d860859550f/src/Avalonia.Controls/TextBox.cs#L418) property. 

When disabled, this option allows the TextEditor to avoid consuming the `Tab` and `Shift+Tab` keys. This is particularly useful when `TextEditor` is used within a form, as users often expect the Tab key to navigate between fields. 

By default, `AcceptsTab` is set to true.