### PR TITLE
Fix SearchPanel keyboard navigation and shortcut handling

### DIFF
--- a/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
@@ -64,19 +64,30 @@ namespace AvaloniaEdit.Editing
         static readonly List<RoutedCommandBinding> CommandBindings = new List<RoutedCommandBinding>();
         static readonly List<KeyBinding> KeyBindings = new List<KeyBinding>();
 
-        private static void AddBinding(RoutedCommand command, EventHandler<ExecutedRoutedEventArgs> handler)
+        private static void AddBinding(
+            RoutedCommand command,
+            EventHandler<ExecutedRoutedEventArgs> handler,
+            EventHandler<CanExecuteRoutedEventArgs> canExecuteHandler = null)
         {
-            CommandBindings.Add(new RoutedCommandBinding(command, handler));
+            CommandBindings.Add(new RoutedCommandBinding(command, handler, canExecuteHandler));
         }
 
-        private static void AddBinding(RoutedCommand command, KeyModifiers modifiers, Key key, EventHandler<ExecutedRoutedEventArgs> handler)
+        private static void AddBinding(
+            RoutedCommand command,
+            KeyModifiers modifiers, Key key,
+            EventHandler<ExecutedRoutedEventArgs> handler,
+            EventHandler<CanExecuteRoutedEventArgs> canExecuteHandler = null)
         {
-            AddBinding(command, new KeyGesture(key, modifiers), handler);
+            AddBinding(command, new KeyGesture(key, modifiers), handler, canExecuteHandler);
         }
 
-        private static void AddBinding(RoutedCommand command, KeyGesture gesture, EventHandler<ExecutedRoutedEventArgs> handler)
+        private static void AddBinding(
+            RoutedCommand command,
+            KeyGesture gesture,
+            EventHandler<ExecutedRoutedEventArgs> handler,
+            EventHandler<CanExecuteRoutedEventArgs> canExecuteHandler = null)
         {
-            AddBinding(command, handler);
+            AddBinding(command, handler, canExecuteHandler);
             KeyBindings.Add(TextAreaDefaultInputHandler.CreateKeyBinding(command, gesture));
         }
 
@@ -132,7 +143,17 @@ namespace AvaloniaEdit.Editing
             foreach (var keyGesture in keymap.MoveCursorToTheEndOfDocumentWithSelection)
                 AddBinding(EditingCommands.SelectToDocumentEnd, keyGesture, OnMoveCaretExtendSelection(CaretMovementType.DocumentEnd));
 
-            AddBinding(ApplicationCommands.SelectAll, OnSelectAll);
+            AddBinding(ApplicationCommands.SelectAll, OnSelectAll, CanSelectAll);
+        }
+
+        private static void CanSelectAll(object target, CanExecuteRoutedEventArgs args)
+        {
+            var textArea = GetTextArea(target);
+            if (textArea is { Document: not null, IsFocused: true })
+            {
+                args.Handled = true;
+                args.CanExecute = true;
+            }
         }
 
         private static void OnSelectAll(object target, ExecutedRoutedEventArgs args)

--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -332,7 +332,7 @@ namespace AvaloniaEdit.Editing
         private static void CanDelete(object target, CanExecuteRoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
-            if (textArea?.Document != null)
+            if (textArea is { Document: not null, IsFocused: true })
             {
                 args.CanExecute = true;
                 args.Handled = true;
@@ -345,9 +345,9 @@ namespace AvaloniaEdit.Editing
 
         private static void CanCut(object target, CanExecuteRoutedEventArgs args)
         {
-            // HasSomethingSelected for copy and cut commands
+            // IsFocused and HasSomethingSelected for copy and cut commands
             var textArea = GetTextArea(target);
-            if (textArea?.Document != null)
+            if (textArea is { Document: not null, IsFocused: true })
             {
                 args.CanExecute = (textArea.Options.CutCopyWholeLine || !textArea.Selection.IsEmpty) && !textArea.IsReadOnly;
                 args.Handled = true;
@@ -356,9 +356,9 @@ namespace AvaloniaEdit.Editing
 
         private static void CanCopy(object target, CanExecuteRoutedEventArgs args)
         {
-            // HasSomethingSelected for copy and cut commands
+            // IsFocused and HasSomethingSelected for copy and cut commands
             var textArea = GetTextArea(target);
-            if (textArea?.Document != null)
+            if (textArea is { Document: not null, IsFocused: true })
             {
                 args.CanExecute = textArea.Options.CutCopyWholeLine || !textArea.Selection.IsEmpty;
                 args.Handled = true;
@@ -489,7 +489,7 @@ namespace AvaloniaEdit.Editing
         private static void CanPaste(object target, CanExecuteRoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
-            if (textArea?.Document != null)
+            if (textArea is { Document: not null, IsFocused: true })
             {
                 args.CanExecute = textArea.ReadOnlySectionProvider.CanInsert(textArea.Caret.Offset);
                 args.Handled = true;

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -970,7 +970,7 @@ namespace AvaloniaEdit.Editing
         {
             base.OnKeyDown(e);
 
-            if (e.Key == Key.Tab && Options.AcceptsTab)
+            if (e.Key == Key.Tab && Options.AcceptsTab && IsFocused)
             {
                 e.Handled = true;
                 if (e.KeyModifiers == KeyModifiers.Shift)

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -192,6 +192,7 @@ namespace AvaloniaEdit.Search
             panel._handler = new SearchInputHandler(textArea, panel);
             textArea.DefaultInputHandler.NestedInputHandlers.Add(panel._handler);
             ((ISetLogicalParent)panel).SetParent(textArea);
+            KeyboardNavigation.SetTabNavigation(panel, KeyboardNavigationMode.Cycle);
             return panel;
         }
 

--- a/src/AvaloniaEdit/Search/SearchPanel.xaml
+++ b/src/AvaloniaEdit/Search/SearchPanel.xaml
@@ -185,8 +185,8 @@
                       VerticalAlignment="Center"
                       Stretch="Uniform"
                       Width="12"
-                      Fill="{Binding $parent[ToggleButton].Foreground}"
-                      Stroke="{Binding $parent[ToggleButton].Foreground}"
+                      Fill="{Binding $parent[Button].Foreground}"
+                      Stroke="{Binding $parent[Button].Foreground}"
                       StrokeThickness="1" />
               </Button>
             </StackPanel>


### PR DESCRIPTION
This PR fixes #482.

### Fix: Keyboard Navigation in SearchPanel
Previously, when pressing the <kbd>Tab</kbd> key inside the `SearchPanel's` `TextBox`, the `TextArea` incorrectly handled the `OnKeyDown` event, marking it as handled. This prevented Avalonia’s built-in `KeyboardNavigation` system from processing the event correctly.

**Solution:**
Avoid processing the <kbd>Tab</kbd> key in the `TextArea` when it is not focused, allowing normal focus traversal.

Additionally, set the `KeyboardNavigationMode` to `Cycle` in the `SearchPanel` to ensure the focus stays within the panel when expected.

### Fix: Shortcut Handling for SearchPanel's TextBox
In our application, the following built-in `ApplicationCommands` were incorrectly handled by AvaloniaEdit instead of the `SearchPanel`'s `TextBox`:

- `ApplicationCommands.SelectAll`
- `ApplicationCommands.Cut`
- `ApplicationCommands.Copy`
- `ApplicationCommands.Paste`
- `ApplicationCommands.Delete`

**Solution:**
Updated `CanExecuteXXX` methods to ensure these commands are only executed/handled when the `TextArea` is focused.
This allows the `SearchPanel`'s `TextBox` to handle its own shortcuts correctly.

### Extra Fix:
Fixed a misspelled control in the `SearchPanel`'s XAML, which caused the `CloseButton` icon to be missing.