### PR TITLE
Copy/Cut/Paste don't work from the context menu

### DIFF
--- a/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/EditingCommandHandler.cs
@@ -332,7 +332,7 @@ namespace AvaloniaEdit.Editing
         private static void CanDelete(object target, CanExecuteRoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
-            if (textArea is { Document: not null, IsFocused: true })
+            if (textArea is { Document: not null })
             {
                 args.CanExecute = true;
                 args.Handled = true;
@@ -345,9 +345,9 @@ namespace AvaloniaEdit.Editing
 
         private static void CanCut(object target, CanExecuteRoutedEventArgs args)
         {
-            // IsFocused and HasSomethingSelected for copy and cut commands
+            // HasSomethingSelected for copy and cut commands
             var textArea = GetTextArea(target);
-            if (textArea is { Document: not null, IsFocused: true })
+            if (textArea is { Document: not null })
             {
                 args.CanExecute = (textArea.Options.CutCopyWholeLine || !textArea.Selection.IsEmpty) && !textArea.IsReadOnly;
                 args.Handled = true;
@@ -356,9 +356,9 @@ namespace AvaloniaEdit.Editing
 
         private static void CanCopy(object target, CanExecuteRoutedEventArgs args)
         {
-            // IsFocused and HasSomethingSelected for copy and cut commands
+            // HasSomethingSelected for copy and cut commands
             var textArea = GetTextArea(target);
-            if (textArea is { Document: not null, IsFocused: true })
+            if (textArea is { Document: not null })
             {
                 args.CanExecute = textArea.Options.CutCopyWholeLine || !textArea.Selection.IsEmpty;
                 args.Handled = true;
@@ -489,7 +489,7 @@ namespace AvaloniaEdit.Editing
         private static void CanPaste(object target, CanExecuteRoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
-            if (textArea is { Document: not null, IsFocused: true })
+            if (textArea is { Document: not null })
             {
                 args.CanExecute = textArea.ReadOnlySectionProvider.CanInsert(textArea.Caret.Offset);
                 args.Handled = true;

--- a/src/AvaloniaEdit/Search/SearchPanel.cs
+++ b/src/AvaloniaEdit/Search/SearchPanel.cs
@@ -42,6 +42,7 @@ namespace AvaloniaEdit.Search
         private TextDocument _currentDocument;
         private SearchResultBackgroundRenderer _renderer;
         private TextBox _searchTextBox;
+        private TextBox _replaceTextBox;
         private TextEditor _textEditor { get; set; }
         private Border _border;
         private int _currentSearchResultIndex = -1;
@@ -228,6 +229,12 @@ namespace AvaloniaEdit.Search
             _textArea.DocumentChanged += TextArea_DocumentChanged;
             KeyDown += SearchLayerKeyDown;
 
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.SelectAll, (sender, e) => SelectAll(e)));
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.Copy, (sender, e) => Copy(e)));
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.Cut, (sender, e) => Cut(e)));
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.Paste, (sender, e) => Paste(e)));
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.Undo, (sender, e) => Undo(e)));
+            CommandBindings.Add(new RoutedCommandBinding(ApplicationCommands.Redo, (sender, e) => Redo(e)));
             CommandBindings.Add(new RoutedCommandBinding(SearchCommands.FindNext, (sender, e) => FindNext()));
             CommandBindings.Add(new RoutedCommandBinding(SearchCommands.FindPrevious, (sender, e) => FindPrevious()));
             CommandBindings.Add(new RoutedCommandBinding(SearchCommands.CloseSearchPanel, (sender, e) => Close()));
@@ -266,6 +273,7 @@ namespace AvaloniaEdit.Search
             base.OnApplyTemplate(e);
             _border = e.NameScope.Find<Border>("PART_Border");
             _searchTextBox = e.NameScope.Find<TextBox>("PART_searchTextBox");
+            _replaceTextBox = e.NameScope.Find<TextBox>("PART_replaceTextBox");
             _messageView = e.NameScope.Find<Panel>("PART_MessageView");
             _messageViewContent = e.NameScope.Find<TextBlock>("PART_MessageContent");
         }
@@ -281,6 +289,84 @@ namespace AvaloniaEdit.Search
             _searchTextBox.SelectionStart = 0;
             _searchTextBox.SelectionEnd = _searchTextBox.Text?.Length ?? 0;
         }
+
+        void SelectAll(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.SelectAll();
+        }
+
+        void Cut(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.Cut();
+        }
+
+        void Copy(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.Copy();
+        }
+
+        void Paste(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.Paste();
+        }
+
+        void Undo(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.Undo();
+        }
+
+        void Redo(ExecutedRoutedEventArgs e)
+        {
+            TextBox focusedTextBox = GetFocusedTextBox();
+
+            if (focusedTextBox == null)
+                return;
+
+            e.Handled = true;
+            focusedTextBox.Redo();
+        }
+
+        TextBox GetFocusedTextBox()
+        {
+            if (_searchTextBox.IsFocused)
+                return _searchTextBox;
+
+            if (_replaceTextBox.IsFocused)
+                return _replaceTextBox;
+
+            return null;
+        }
+
 
         /// <summary>
         /// Moves to the next occurrence in the file starting at the next position from current caret offset.

--- a/src/AvaloniaEdit/Search/SearchPanel.xaml
+++ b/src/AvaloniaEdit/Search/SearchPanel.xaml
@@ -196,7 +196,8 @@
                         Margin="0 5 0 0 "
                         Grid.Column="2"
                         Grid.Row="1">
-              <TextBox Name="ReplaceBox" Watermark="{x:Static ae:SR.ReplaceLabel}"
+              <TextBox Watermark="{x:Static ae:SR.ReplaceLabel}"
+                       Name="PART_replaceTextBox"
                        IsVisible="{Binding IsReplaceMode, RelativeSource={RelativeSource TemplatedParent}}"
                        Grid.Column="1"
                        Grid.Row="1"


### PR DESCRIPTION
Fix the `EditingCommandHandler`: The context menu actions (copy/cut/paste) didn't work because the TextArea is not focused when executing those actions from the context menu.