### PR TITLE
Fix visual line crash when deleting text with line numbers

### DIFF
--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -700,6 +700,7 @@ namespace AvaloniaEdit.Rendering
         /// </summary>
         private void ClearVisualLines()
         {
+            _visibleVisualLines = null;
             if (_allVisualLines.Count != 0)
             {
                 foreach (var visualLine in _allVisualLines)
@@ -707,8 +708,6 @@ namespace AvaloniaEdit.Rendering
                     DisposeVisualLine(visualLine);
                 }
                 _allVisualLines.Clear();
-
-                _visibleVisualLines = new ReadOnlyCollection<VisualLine>(_allVisualLines.ToArray());
             }
         }
 
@@ -719,6 +718,7 @@ namespace AvaloniaEdit.Rendering
                 throw new ArgumentException("Cannot dispose visual line because it is in construction!");
             }
 
+            _visibleVisualLines = null;
             visualLine.Dispose();
             RemoveInlineObjects(visualLine);
         }


### PR DESCRIPTION
Fixes a crash that can occur when deleting large text with line numbers enabled.