### PR TITLE
Fix: Rectangular selection ignores scroll offset

### DIFF
--- a/src/AvaloniaEdit/Rendering/BackgroundGeometryBuilder.cs
+++ b/src/AvaloniaEdit/Rendering/BackgroundGeometryBuilder.cs
@@ -260,10 +260,13 @@ namespace AvaloniaEdit.Rendering
 					} else {
 						right = visualLine.GetTextLineVisualXPosition(lastTextLine, segmentEndVc);
 					}
+
+					left -= scrollOffset.X;
+					right -= scrollOffset.X;
 					Rect extendSelection = new Rect(Math.Min(left, right), y, Math.Abs(right - left), line.Height);
 					if (lastRect != default) {
 						if (extendSelection.Intersects(lastRect)) {
-							lastRect.Union(extendSelection);
+							lastRect = lastRect.Union(extendSelection);
 							yield return lastRect;
 						} else {
 							// If the end of the line is in an RTL segment, keep lastRect and extendSelection separate.


### PR DESCRIPTION
Fixes #472.

When a selection extends beyond the visual line into the "virtual space" then the `BackgroundGeometryBuilder` creates two segments per line. One for the visible text, and one for the virtual space.

The segment for the virtual space didn't apply the scroll offset. This is now fixed.