### PR TITLE
Fix: Buttons not drawn when unsorted

### DIFF
--- a/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
+++ b/src/AvaloniaEdit.Demo/MainWindow.xaml.cs
@@ -270,6 +270,7 @@ namespace AvaloniaEdit.Demo
         private void AddControlButton_Click(object sender, RoutedEventArgs e)
         {
             _generator.controls.Add(new Pair(_textEditor.CaretOffset, new Button() { Content = "Click me", Cursor = Cursor.Default }));
+            _generator.controls.Sort(0, _generator.controls.Count, _generator);
             _textEditor.TextArea.TextView.Redraw();
         }
 


### PR DESCRIPTION
When clicking `Add Button` in the `AvaloniaEdit.Demo`, some buttons are never drawn.

### Cause
The `ElementGenerator` uses `BinarySearch` to find the first offset with a `Button`. But the list is never actually sorted in the demo.

### Solution
Sort the list after each insert.