### PR TITLE
Fix: Insert at wrong offset in virtual space with EOL glyphs

### DIFF
--- a/src/AvaloniaEdit/Editing/Selection.cs
+++ b/src/AvaloniaEdit/Editing/Selection.cs
@@ -107,7 +107,7 @@ namespace AvaloniaEdit.Editing
                 var line = TextArea.Document.GetLineByNumber(start.Line);
                 var lineText = TextArea.Document.GetText(line);
                 var vLine = TextArea.TextView.GetOrConstructVisualLine(line);
-                var colDiff = start.VisualColumn - vLine.VisualLengthWithEndOfLineMarker;
+                var colDiff = start.VisualColumn - vLine.VisualLength;
                 if (colDiff > 0)
                 {
                     var additionalSpaces = "";


### PR DESCRIPTION
Fixes #427.

`AddSpacesIfRequired` incorrectly counts the line length when EOL markers are enabled.
The EOL marker itself shouldn't be counted.