### PR TITLE
Use a traditional constructor instead of a primary constructor

### DIFF
--- a/src/AvaloniaEdit/Document/DataObjectCopyingEventArgs.cs
+++ b/src/AvaloniaEdit/Document/DataObjectCopyingEventArgs.cs
@@ -4,11 +4,18 @@ using AvaloniaEdit.Utils;
 
 namespace AvaloniaEdit.Document;
 
-public class DataObjectCopyingEventArgs(IDataObject dataObject, bool isDragDrop) :
-    RoutedEventArgs(DataObjectEx.DataObjectCopyingEvent)
+public class DataObjectCopyingEventArgs : RoutedEventArgs
 {
     public bool CommandCancelled { get; private set; }
-    public IDataObject DataObject { get; } = dataObject;
-    public bool IsDragDrop { get; } = isDragDrop;
+    public IDataObject DataObject { get; private set; }
+    public bool IsDragDrop { get; private set; }
+
+    public DataObjectCopyingEventArgs(IDataObject dataObject, bool isDragDrop) :
+        base(DataObjectEx.DataObjectCopyingEvent)
+    {
+        DataObject = dataObject;
+        IsDragDrop = isDragDrop;
+    }
+
     public void CancelCommand() => CommandCancelled = true;
 }


### PR DESCRIPTION
Refactored `DataObjectCopyingEventArgs` to use a traditional constructor instead of a primary constructor.

Why
- **Consistency**: All other EventArgs-based classes in the codebase use traditional constructors.
- **Compatibility**: The project targets `netstandard2.0;net6.0`, so we can stick to C# 11 features for now.