### PR TITLE
fix(VisualLineElementTextRunProperties): potential crash of invalid EmSize

### DIFF
--- a/src/AvaloniaEdit/Rendering/VisualLineElementTextRunProperties.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLineElementTextRunProperties.cs
@@ -143,7 +143,7 @@ namespace AvaloniaEdit.Rendering
 		/// </summary>
 		public void SetFontRenderingEmSize(double value)
 		{
-			_fontRenderingEmSize = value;
+			_fontRenderingEmSize = value > 0 ? value : 1.0;
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
This pull request includes a small but significant change to the `SetFontRenderingEmSize` method in `VisualLineElementTextRunProperties.cs`. The change ensures that the font rendering size does not drop below a minimum value of `0`(will fallback to 1.0), preventing potential rendering issues.If GlobalTextRunProperties.FontRenderingEmSize is smaller than 2.0 will cause a crash because the valid value is bigger than zero, so we need add an fallback value for 


## Reproduce
* Run the latest sample
* Enable `View EOL` in toolbar
* Use <kbd>Ctrl</kbd> + <kbd>MouseWeel Down</kbd> to decrease the font size as you can

When we decrease to 2, the app crashed

## Related source

https://github.com/AvaloniaUI/AvaloniaEdit/blob/4290c4296eb2fc46290d09733a0fb3787eb19707/src/AvaloniaEdit.Demo/MainWindow.xaml.cs#L109