### PR TITLE
Implement some methods which not implemented in porting

### DIFF
--- a/src/AvaloniaEdit/CodeCompletion/InsightWindow.cs
+++ b/src/AvaloniaEdit/CodeCompletion/InsightWindow.cs
@@ -17,6 +17,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using Avalonia;
+using Avalonia.Controls;
 using AvaloniaEdit.Editing;
 
 namespace AvaloniaEdit.CodeCompletion
@@ -38,12 +40,21 @@ namespace AvaloniaEdit.CodeCompletion
 
         private void Initialize()
         {
-            // TODO: working area
-            //var caret = this.TextArea.Caret.CalculateCaretRectangle();
-            //var pointOnScreen = this.TextArea.TextView.PointToScreen(caret.Location - this.TextArea.TextView.ScrollOffset);
-            //Rect workingArea = System.Windows.Forms.Screen.FromPoint(pointOnScreen.ToSystemDrawing()).WorkingArea.ToWpf().TransformFromDevice(this);
-            //MaxHeight = workingArea.Height;
-            //MaxWidth = Math.Min(workingArea.Width, Math.Max(1000, workingArea.Width * 0.6));
+            var caret = this.TextArea.Caret.CalculateCaretRectangle();
+            var topLevel = TopLevel.GetTopLevel(this.TextArea.TextView) as WindowBase;
+            if (topLevel?.Presenter != null)
+            {
+                var presenter = topLevel.Presenter;
+                var pointOnScreen = presenter.PointToScreen(caret.Position - this.TextArea.TextView.ScrollOffset);
+                var screen = topLevel.Screens.ScreenFromPoint(pointOnScreen);
+
+                if (screen != null)
+                {
+                    var scaledWorkingArea = screen.WorkingArea.ToRect(topLevel.RenderScaling);
+                    MaxHeight = scaledWorkingArea.Height;
+                    MaxWidth = Math.Min(scaledWorkingArea.Width, Math.Max(1000, scaledWorkingArea.Width * 0.6));
+                }
+            }
         }
 
         /// <summary>

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -526,20 +526,18 @@ namespace AvaloniaEdit.Rendering
         // Caller of RemoveInlineObjectRun will remove it from inlineObjects collection.
         private void RemoveInlineObjectRun(InlineObjectRun ior, bool keepElement)
         {
-            // TODO: Focus
-            //if (!keepElement && ior.Element.IsKeyboardFocusWithin)
-            //{
-            //    // When the inline element that has the focus is removed, it will reset the
-            //    // focus to the main window without raising appropriate LostKeyboardFocus events.
-            //    // To work around this, we manually set focus to the next focusable parent.
-            //    UIElement element = this;
-            //    while (element != null && !element.Focusable)
-            //    {
-            //        element = VisualTreeHelper.GetParent(element) as UIElement;
-            //    }
-            //    if (element != null)
-            //        Keyboard.Focus(element);
-            //}
+            if (!keepElement && ior.Element.IsKeyboardFocusWithin)
+            {
+                // When the inline element that has the focus is removed, it will reset the
+                // focus to the main window without raising appropriate LostKeyboardFocus events.
+                // To work around this, we manually set focus to the next focusable parent.
+                Control element = this;
+                while (element != null && !element.Focusable)
+                {
+                    element = element.GetVisualParent() as Control;
+                }
+                element?.Focus();
+            }
             ior.VisualLine = null;
             if (!keepElement)
                 VisualChildren.Remove(ior.Element);

--- a/src/AvaloniaEdit/Utils/PixelSnapHelpers.cs
+++ b/src/AvaloniaEdit/Utils/PixelSnapHelpers.cs
@@ -18,6 +18,7 @@
 
 using System;
 using Avalonia;
+using Avalonia.Controls;
 
 namespace AvaloniaEdit.Utils
 {
@@ -32,17 +33,18 @@ namespace AvaloniaEdit.Utils
 		/// </summary>
 		public static Size GetPixelSize(Visual visual)
 		{
-			if (visual == null)
-				throw new ArgumentNullException(nameof(visual));
-
-            // TODO-avedit
-            //PresentationSource source = PresentationSource.FromVisual(visual);
-            //if (source != null) {
-            //	Matrix matrix = source.CompositionTarget.TransformFromDevice;
-            //	return new Size(matrix.M11, matrix.M22);
-            //} else {
-            return new Size(1, 1);
-            //}
+            if (visual == null)
+                throw new ArgumentNullException(nameof(visual));
+            var source = TopLevel.GetTopLevel(visual);
+            if (source != null)
+            {
+                var scaling = source.RenderScaling;
+                return new Size(1 / scaling , 1 / scaling);
+            }
+            else
+            {
+                return new Size(1, 1);
+            }
         }
 		
 		/// <summary>


### PR DESCRIPTION
- `src/AvaloniaEdit/CodeCompletion/InsightWindow.cs`
  - I have tested it via creating it (no crashs and adds null check)
  - and I compared it to `AvalonEdit`, the `MaxHeight` and `MaxWidth` have same value while change system scaling

- `src/AvaloniaEdit/Rendering/TextView.cs`
  - I have tested it via many tries on clike the `AvaloniaEdit.Demo`'s `Add Buttons` `Clear Buttons`(no crashs)

- `src/AvaloniaEdit/Utils/PixelSnapHelpers.cs`
  - Same as file `InsightWindow.cs`, I compared it to `AvalonEdit` and they are behaved same value