### PR TITLE
Better UX with pen or touch input

### DIFF
--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -430,7 +430,8 @@ namespace AvaloniaEdit.Editing
 
         private void TextArea_MouseLeftButtonDown(object sender, PointerPressedEventArgs e)
         {
-            if (e.GetCurrentPoint(TextArea).Properties.IsLeftButtonPressed == false)
+            var pointer = e.GetCurrentPoint(TextArea);
+            if (pointer.Properties.IsLeftButtonPressed == false)
             {
                 if (TextArea.RightClickMovesCaret == true && e.Handled == false)
                 {
@@ -439,9 +440,7 @@ namespace AvaloniaEdit.Editing
             }
             else
             {
-                TextArea.Cursor = Cursor.Parse("IBeam");
-
-                var pointer = e.GetCurrentPoint(TextArea);
+                TextArea.Cursor = new Cursor(StandardCursorType.Ibeam);
 
                 _mode = SelectionMode.None;
                 if (!e.Handled)
@@ -466,6 +465,10 @@ namespace AvaloniaEdit.Editing
                     var oldPosition = TextArea.Caret.Position;
                     SetCaretOffsetToMousePosition(e);
 
+                    if (e.Pointer.Type is PointerType.Pen or PointerType.Touch)
+                    {
+                        return;
+                    }
 
                     if (!shift)
                     {


### PR DESCRIPTION
### Current behavior

Touch: impossible to do anything, scrolling doesn't work because of broken selection. Selection doesn't work for unknown reason.
Pen: any interaction starts selection, it's not possible to scroll.

### This PR behavior

Selection is effectively disabled for pen and touch input, but it is possible to scroll and move caret.
This behavior is consistent with VSCode and Rider.