### PR TITLE
Fix: TextEditor.SelectAll method doesn't work

### DIFF
--- a/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/src/AvaloniaEdit/Editing/CaretNavigationCommandHandler.cs
@@ -149,7 +149,7 @@ namespace AvaloniaEdit.Editing
         private static void CanSelectAll(object target, CanExecuteRoutedEventArgs args)
         {
             var textArea = GetTextArea(target);
-            if (textArea is { Document: not null, IsFocused: true })
+            if (textArea is { Document: not null })
             {
                 args.Handled = true;
                 args.CanExecute = true;


### PR DESCRIPTION
Fixes #512

The `RoutedCommand`'s `CanExecute` handler shouldn't check whether editor `IsFocused`. The source of the `RoutedCommand` (`Button`, `MenuItem`, etc.) has focus when the command is executed. (When using the context menu, the focus will automatically move back to the editor when the context menu is closed.)