### PR TITLE
Fix #511 by improving README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,37 @@ AvaloniaEdit currently consists of 2 packages
 * Create an [empty Avalonia application](https://docs.avaloniaui.net/docs/getting-started).
 * Add a the [nuget reference](https://www.nuget.org/packages/Avalonia.AvaloniaEdit/#versions-body-tab) to the latest version:
 `<PackageReference Include="Avalonia.AvaloniaEdit" Version="x.y.z.t" />`
-* Include the *needed styles* into your `<Application.Styles>` in your `App.xaml`: 
+* Include the *needed styles* into your `<Application.Styles>` in your `App.xaml`:
+  ```xaml
+  <Application xmlns="https://github.com/avaloniaui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               x:Class="MyAvaloniaApplication.App"
+               RequestedThemeVariant="Default">
+    <Application.Styles>
+      <FluentTheme />
+
+      <!-- AvaloniaEdit styles (required!) -->
+      <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
+
+    </Application.Styles>
+  </Application>
+  ```
   * If you're using `0.10.x.y` based versions, include `<StyleInclude Source="avares://AvaloniaEdit/AvaloniaEdit.xaml" />`
   * If you're `11.x.y` based versions, include `<StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />`
 * Finally, add the AvaloniaEdit editor into your window:
-```xaml
-<Window xmlns="https://github.com/avaloniaui"
-        ...
-        xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
-        ...>
-  ...
-  <AvaloniaEdit:TextEditor Text="Hello AvaloniaEdit!"
-                           ShowLineNumbers="True"
-                           FontFamily="Cascadia Code,Consolas,Menlo,Monospace"/>
-  ...
-</Window>
-```
+    ```xaml
+    <Window xmlns="https://github.com/avaloniaui"
+            ...
+            xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
+            ...>
+      ...
+      <AvaloniaEdit:TextEditor Text="Hello AvaloniaEdit!"
+                               ShowLineNumbers="True"
+                               FontFamily="Cascadia Code,Consolas,Menlo,Monospace"/>
+      ...
+    </Window>
+    ```
+
 You can see the [Demo Application](https://github.com/AvaloniaUI/AvaloniaEdit/tree/master/src/AvaloniaEdit.Demo) as a reference.
 
  ### How to set up TextMate theme and syntax highlighting for my project?


### PR DESCRIPTION
Fixes #511

Users often forget to add the AvaloniaEdit styles in `App.xaml`. This step is mentioned in the `README.md`, but can easily be missed. I know because it happened to me as well.

Users often just look for source code examples that they can copy-paste. Therefore, I suggest to add an example for `App.xaml` and make it the first example in `README.md`.