### PR TITLE
Optimize heap allocations in CharRope.ToString

### DIFF
--- a/src/AvaloniaEdit/Utils/CharRope.cs
+++ b/src/AvaloniaEdit/Utils/CharRope.cs
@@ -54,9 +54,15 @@ namespace AvaloniaEdit.Utils
 			#endif
 			if (length == 0)
 				return string.Empty;
+			
+#if NET6_0_OR_GREATER
+			return string.Create(length, (rope, startIndex, length), (dest, x) =>
+				x.rope.CopyTo(x.startIndex, dest, 0, x.length));
+#else
 			char[] buffer = new char[length];
 			rope.CopyTo(startIndex, buffer, 0, length);
 			return new string(buffer);
+#endif
 		}
 		
 		/// <summary>

--- a/src/AvaloniaEdit/Utils/Rope.cs
+++ b/src/AvaloniaEdit/Utils/Rope.cs
@@ -599,7 +599,7 @@ namespace AvaloniaEdit.Utils
             }
         }
 
-        internal static void VerifyArrayWithRange(T[] array, int arrayIndex, int count)
+        internal static void VerifyArrayWithRange(Span<T> array, int arrayIndex, int count)
         {
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
@@ -777,6 +777,18 @@ namespace AvaloniaEdit.Utils
         /// </remarks>
         public void CopyTo(T[] array, int arrayIndex)
         {
+            CopyTo(array.AsSpan(), arrayIndex);
+        }
+
+        /// <summary>
+        /// Copies the whole content of the rope into the specified array.
+        /// Runs in O(N).
+        /// </summary>
+        /// <remarks>
+        /// This method counts as a read access and may be called concurrently to other read accesses.
+        /// </remarks>
+        public void CopyTo(Span<T> array, int arrayIndex)
+        {
             CopyTo(0, array, arrayIndex, Length);
         }
 
@@ -787,7 +799,7 @@ namespace AvaloniaEdit.Utils
         /// <remarks>
         /// This method counts as a read access and may be called concurrently to other read accesses.
         /// </remarks>
-        public void CopyTo(int index, T[] array, int arrayIndex, int count)
+        public void CopyTo(int index, Span<T> array, int arrayIndex, int count)
         {
             VerifyRange(index, count);
             VerifyArrayWithRange(array, arrayIndex, count);

--- a/src/AvaloniaEdit/Utils/RopeNode.cs
+++ b/src/AvaloniaEdit/Utils/RopeNode.cs
@@ -356,7 +356,7 @@ namespace AvaloniaEdit.Utils
         /// <summary>
         /// Copies from this node to the array.
         /// </summary>
-        internal void CopyTo(int index, T[] array, int arrayIndex, int count)
+        internal void CopyTo(int index, Span<T> array, int arrayIndex, int count)
         {
             if (Height == 0)
             {
@@ -368,7 +368,7 @@ namespace AvaloniaEdit.Utils
                 else
                 {
                     // leaf node
-                    Array.Copy(Contents, index, array, arrayIndex, count);
+                    Contents.AsSpan(index, count).CopyTo(array.Slice(arrayIndex, count));
                 }
             }
             else


### PR DESCRIPTION
Hi team,

I noticed that `CharRope.ToString` in AvaloniaEdit performs a large number of heap allocations, especially with large strings.

This pull request optimizes `CharRope.ToString` to use `string.Create` on .NET 6 and newer targets, which significantly improves performance. For older versions, the existing logic is kept as a fallback to ensure backward compatibility.

To implement this, I've added `Span<T>` overrides to several internal methods or updated them to use `Span<T>`.

This optimization should lead to reduced memory usage and contribute to better overall application performance.

I'd appreciate it if you could take a look. Thank you!