### PR TITLE
fixed jumping / unaligned text with special characters and collapsed folding

### DIFF
--- a/src/AvaloniaEdit/Folding/FoldingElementGenerator.cs
+++ b/src/AvaloniaEdit/Folding/FoldingElementGenerator.cs
@@ -154,10 +154,9 @@ namespace AvaloniaEdit.Folding
 				string title = foldingSection.Title;
 				if (string.IsNullOrEmpty(title))
 					title = "...";
-				var p = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-				p.SetForegroundBrush(TextBrush);
-				var textFormatter = TextFormatterFactory.Create(CurrentContext.TextView);
-				var text = FormattedTextElement.PrepareText(textFormatter, title, p);
+				var properties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+				properties.SetForegroundBrush(TextBrush);
+				var text = TextFormatter.Current.FormatLine(new SimpleTextSource(title, properties), 0, double.MaxValue, new GenericTextParagraphProperties(properties));
 				return new FoldingLineElement(foldingSection, text, foldedUntil - offset, TextBrush);
 			} else {
 				return null;

--- a/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
+++ b/src/AvaloniaEdit/Rendering/SingleCharacterElementGenerator.cs
@@ -103,30 +103,32 @@ namespace AvaloniaEdit.Rendering
         {
             var c = CurrentContext.Document.GetCharAt(offset);
 
-            if (ShowSpaces && c == ' ')
-            {
-                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                runProperties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
-                return new SpaceTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
-                        CurrentContext.TextView.Options.ShowSpacesGlyph,
-                        runProperties));
-            }
-            else if (ShowTabs && c == '\t')
-            {
-                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                runProperties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
-                return new TabTextElement(CurrentContext.TextView.CachedElements.GetTextForNonPrintableCharacter(
-                        CurrentContext.TextView.Options.ShowTabsGlyph,
-                        runProperties));
-            }
-            else if (ShowBoxForControlCharacters && char.IsControl(c))
-            {
-                var runProperties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
-                runProperties.SetForegroundBrush(Brushes.White);
-                var textFormatter = TextFormatterFactory.Create(CurrentContext.TextView);
-                var text = FormattedTextElement.PrepareText(textFormatter, TextUtilities.GetControlCharacterName(c), runProperties);
-                return new SpecialCharacterBoxElement(text);
-            }
+			if (ShowSpaces && (c == ' '))
+			{
+				var properties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+				properties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+				var textSource = new SimpleTextSource(CurrentContext.TextView.Options.ShowSpacesGlyph, properties);
+				var textLine = TextFormatter.Current.FormatLine(textSource, 0, double.MaxValue, new GenericTextParagraphProperties(properties));
+				return new SpaceTextElement(textLine);
+			}
+			
+			if (ShowTabs && (c == '\t'))
+			{
+				var properties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+				properties.SetForegroundBrush(CurrentContext.TextView.NonPrintableCharacterBrush);
+				var textSource = new SimpleTextSource(CurrentContext.TextView.Options.ShowTabsGlyph, properties);
+				var textLine = TextFormatter.Current.FormatLine(textSource, 0, double.MaxValue, new GenericTextParagraphProperties(properties));
+				return new TabTextElement(textLine);
+			}
+
+			if (ShowBoxForControlCharacters && char.IsControl(c))
+			{
+				var properties = new VisualLineElementTextRunProperties(CurrentContext.GlobalTextRunProperties);
+				properties.SetForegroundBrush(Brushes.White);
+				var textSource = new SimpleTextSource(TextUtilities.GetControlCharacterName(c), properties);
+				var textLine = TextFormatter.Current.FormatLine(textSource, 0, double.MaxValue, new GenericTextParagraphProperties(properties));
+				return new SpecialCharacterBoxElement(textLine);
+			}
 
             return null;
         }


### PR DESCRIPTION
What has been fixed:

1. When turning on or off spaces the text will jump up and down (incorrect height).
2. When collapsing a foldable area the line height was changing.