### PR TITLE
Add CaretBrush as DirectProperty on TextArea so it can be defined via markup

### DIFF
--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -757,6 +757,23 @@ namespace AvaloniaEdit.Editing
             get => GetValue(RightClickMovesCaretProperty);
             set => SetValue(RightClickMovesCaretProperty, value);
         }
+
+        /// <summary>
+        /// Defines the <see cref="CaretBrush"/> property
+        /// </summary>
+        public static readonly DirectProperty<TextArea, IBrush> CaretBrushProperty =
+            AvaloniaProperty.RegisterDirect<TextArea, IBrush>(nameof(CaretBrush),
+                getter: (textArea) => textArea.Caret.CaretBrush,
+                setter: (textArea, brush) => textArea.Caret.CaretBrush = brush);
+
+        /// <summary>
+        /// Gets or sets the brush used for Caret.
+        /// </summary>
+        public IBrush CaretBrush
+        {
+            get => GetValue(CaretBrushProperty);
+            set => SetValue(CaretBrushProperty, value);
+        }
         #endregion
 
         #region Focus Handling (Show/Hide Caret)

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -403,6 +403,27 @@ namespace AvaloniaEdit
         }
         #endregion
 
+        #region CaretBrush
+        /// <summary>
+        /// Defines the <see cref="CaretBrush"/> property
+        /// </summary>
+        public static readonly StyledProperty<IBrush> CaretBrushProperty =
+            AvaloniaProperty.Register<TextArea, IBrush>(nameof(CaretBrush));
+
+        /// <summary>
+        /// Gets or sets the brush used for Caret.
+        /// </summary>
+        public IBrush CaretBrush
+        {
+            get => this.TextArea.Caret.CaretBrush;
+            set
+            {
+                SetValue(CaretBrushProperty, value);
+                this.TextArea.Caret.CaretBrush = value;
+            }
+        }
+        #endregion
+
         #region WordWrap
         /// <summary>
         /// Word wrap dependency property.

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -403,25 +403,6 @@ namespace AvaloniaEdit
         }
         #endregion
 
-        #region CaretBrush
-        /// <summary>
-        /// Defines the <see cref="CaretBrush"/> property
-        /// </summary>
-        public static readonly DirectProperty<TextEditor, IBrush> CaretBrushProperty =
-            AvaloniaProperty.RegisterDirect<TextEditor, IBrush>(nameof(CaretBrush),
-                getter: (editor) => editor.TextArea.Caret.CaretBrush,
-                setter: (editor, brush) => editor.TextArea.Caret.CaretBrush = brush);
-
-        /// <summary>
-        /// Gets or sets the brush used for Caret.
-        /// </summary>
-        public IBrush CaretBrush
-        {
-            get => GetValue(CaretBrushProperty);
-            set => SetValue(CaretBrushProperty, value);
-        }
-        #endregion
-
         #region WordWrap
         /// <summary>
         /// Word wrap dependency property.

--- a/src/AvaloniaEdit/TextEditor.cs
+++ b/src/AvaloniaEdit/TextEditor.cs
@@ -407,20 +407,18 @@ namespace AvaloniaEdit
         /// <summary>
         /// Defines the <see cref="CaretBrush"/> property
         /// </summary>
-        public static readonly StyledProperty<IBrush> CaretBrushProperty =
-            AvaloniaProperty.Register<TextArea, IBrush>(nameof(CaretBrush));
+        public static readonly DirectProperty<TextEditor, IBrush> CaretBrushProperty =
+            AvaloniaProperty.RegisterDirect<TextEditor, IBrush>(nameof(CaretBrush),
+                getter: (editor) => editor.TextArea.Caret.CaretBrush,
+                setter: (editor, brush) => editor.TextArea.Caret.CaretBrush = brush);
 
         /// <summary>
         /// Gets or sets the brush used for Caret.
         /// </summary>
         public IBrush CaretBrush
         {
-            get => this.TextArea.Caret.CaretBrush;
-            set
-            {
-                SetValue(CaretBrushProperty, value);
-                this.TextArea.Caret.CaretBrush = value;
-            }
+            get => GetValue(CaretBrushProperty);
+            set => SetValue(CaretBrushProperty, value);
         }
         #endregion
 


### PR DESCRIPTION
With Consolonia we need to assign a custom brush to CaretBrush. The problem is that currently that's buried deep in TextArea.Caret.CaretBrush, which is not a styled property and can't be addressed via styles/themes.

This PR adds a StyledProperty **CaretBrush**  to TextArea and plumbs it through to the underlining object.
