### PR TITLE
Support PreeditText

### DIFF
--- a/src/AvaloniaEdit/Editing/CaretLayer.cs
+++ b/src/AvaloniaEdit/Editing/CaretLayer.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -90,7 +91,44 @@ namespace AvaloniaEdit.Editing
         public override void Render(DrawingContext drawingContext)
         {
             base.Render(drawingContext);
+            
+            var caretRect = _caretRectangle;
+            
+            if (!string.IsNullOrEmpty(_textArea.PreeditText))
+            {
+                var caretPos = new Point(
+                    caretRect.X - TextView.HorizontalOffset,
+                    caretRect.Y - TextView.VerticalOffset
+                );
+                
+                var formattedText = new FormattedText(
+                    _textArea.PreeditText,
+                    CultureInfo.CurrentCulture,
+                    _textArea.FlowDirection,
+                    new Typeface(_textArea.FontFamily, _textArea.FontStyle, _textArea.FontWeight,
+                        _textArea.FontStretch),
+                    _textArea.FontSize,
+                    Brushes.Black
+                );
 
+                var textBounds = new Rect(
+                    caretPos.X,
+                    caretPos.Y,
+                    formattedText.Width,
+                    formattedText.Height
+                );
+                drawingContext.FillRectangle(Brushes.White, textBounds);
+                
+                drawingContext.DrawText(formattedText, caretPos);
+                
+                caretRect = new Rect(
+                    caretRect.X + formattedText.Width,
+                    caretRect.Y,
+                    caretRect.Width,
+                    caretRect.Height
+                );
+            }
+            
             if (_isVisible && _blink)
             {
                 var caretBrush = CaretBrush ?? TextView.GetValue(TextBlock.ForegroundProperty);
@@ -105,10 +143,10 @@ namespace AvaloniaEdit.Editing
                     }
                 }
 
-                var r = new Rect(_caretRectangle.X - TextView.HorizontalOffset,
-                                  _caretRectangle.Y - TextView.VerticalOffset,
-                                  _caretRectangle.Width,
-                                  _caretRectangle.Height);
+                var r = new Rect(caretRect.X - TextView.HorizontalOffset,
+                                  caretRect.Y - TextView.VerticalOffset,
+                                  caretRect.Width,
+                                  caretRect.Height);
 
                 drawingContext.FillRectangle(caretBrush, PixelSnapHelpers.Round(r, PixelSnapHelpers.GetPixelSize(this)));
             }

--- a/src/AvaloniaEdit/Editing/TextArea.cs
+++ b/src/AvaloniaEdit/Editing/TextArea.cs
@@ -774,6 +774,15 @@ namespace AvaloniaEdit.Editing
             get => GetValue(CaretBrushProperty);
             set => SetValue(CaretBrushProperty, value);
         }
+        
+        /// <summary>
+        /// Gets the preedit text (text currently being composed using an input method).
+        /// </summary>
+        internal string PreeditText
+        {
+            get; private set;
+        }
+        
         #endregion
 
         #region Focus Handling (Show/Hide Caret)
@@ -1232,7 +1241,7 @@ namespace AvaloniaEdit.Editing
 
             public override Visual TextViewVisual => _textArea;
 
-            public override bool SupportsPreedit => false;
+            public override bool SupportsPreedit => true;
 
             public override bool SupportsSurroundingText => true;
 
@@ -1305,7 +1314,12 @@ namespace AvaloniaEdit.Editing
 
             public override void SetPreeditText(string text)
             {
+                if (_textArea == null)
+                    return;
+                
+                _textArea.PreeditText = text;
 
+                _textArea.TextView.InvalidateLayer(KnownLayer.Caret);
             }
         }
     }


### PR DESCRIPTION
I'm unsure whether to underline text or how to do so efficiently. Visually, I don't see much difference between underlining and leaving it plain.

_NOTE: I'd set the AvaloniaSampleVersion to 11.3.6 for getting this fix https://github.com/AvaloniaUI/Avalonia/pull/18759_

Fixes #524
![vs](https://github.com/user-attachments/assets/f6a6122a-61fe-4a18-8cc6-8b5ea75a8282)
![avaloniaedit](https://github.com/user-attachments/assets/9ccd8707-4812-4a5c-8480-4de2bbec7983)

Achieving Chromium's effect where pre-edited text compresses subsequent content would likely incur performance overhead.
Therefore, I've implemented the same effect as Visual Studio.

<img width="345" height="144" alt="image" src="https://github.com/user-attachments/assets/f4dfda38-28de-4fb1-9e54-bb81fed8dc53" />
<img width="414" height="175" alt="image" src="https://github.com/user-attachments/assets/cf194bbb-35ec-43a2-9bcd-35bd9255e65a" />