### PR TITLE
Remove hardcoded line height factor

### DIFF
--- a/src/AvaloniaEdit/Rendering/VisualLineTextParagraphProperties.cs
+++ b/src/AvaloniaEdit/Rendering/VisualLineTextParagraphProperties.cs
@@ -34,7 +34,7 @@ namespace AvaloniaEdit.Rendering
 
 		public override FlowDirection FlowDirection => FlowDirection.LeftToRight;
 		public override TextAlignment TextAlignment => TextAlignment.Left;
-		public override double LineHeight => DefaultTextRunProperties.FontRenderingEmSize * 1.35;
+		public override double LineHeight => double.NaN;
 		public override bool FirstLineInParagraph => firstLineInParagraph;
 		public override TextRunProperties DefaultTextRunProperties => defaultTextRunProperties;
 


### PR DESCRIPTION
Remove the hardcoded line height factor in `VisualLineTextParagraphProperties`.
Use `NaN` to determine line height automatically from font characteristics.

Fixes #526

The resulting line spacing is a little bit tighter than before, but more in line with the font characteristics. 

Here is before (left, factor 1.35) and after (right, using NaN).

<img width="962" height="379" alt="image" src="https://github.com/user-attachments/assets/b565d143-b773-4749-b2cb-ff0b7d2a7afc" />

As mentioned in #526, an additional option `TextEditorOptions.LineSpacingFactor` would be nice to have. But this can be a separate change.

