### PR TITLE
Bumped master version to 11.4.999

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  packageVersion: '11.3.999-cibuild00$(Build.BuildId)-beta'
+  packageVersion: '11.4.999-cibuild00$(Build.BuildId)-beta'
 jobs:
 - job: Windows
   pool:


### PR DESCRIPTION
Bumped version on master to 11.4.999 so that CI builds have a higher version than stable builds.

