### PR TITLE
Optimize DocumentSnapshot and add parameter validation

### DIFF
--- a/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
+++ b/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 using AvaloniaEdit.Document;
 
@@ -8,9 +7,9 @@ namespace AvaloniaEdit.TextMate
     public class DocumentSnapshot
     {
         private LineRange[] _lineRanges;
-        private TextDocument _document;
+        private readonly TextDocument _document;
         private ITextSource _textSource;
-        private object _lock = new object();
+        private readonly object _lock = new object();
         private int _lineCount;
 
         public int LineCount
@@ -30,10 +29,15 @@ namespace AvaloniaEdit.TextMate
         {
             lock (_lock)
             {
-                var tmpList = _lineRanges.ToList();
-                tmpList.RemoveRange(startLine, endLine - startLine + 1);
-                _lineRanges = tmpList.ToArray();
-                _lineCount = _lineRanges.Length;
+                int removeCount = endLine - startLine + 1;
+                int shiftCount = _lineCount - (endLine + 1);
+                if (shiftCount > 0)
+                {
+                    Array.Copy(_lineRanges, endLine + 1, _lineRanges, startLine, shiftCount);
+                }
+
+                _lineCount -= removeCount;
+                Array.Resize(ref _lineRanges, _lineCount);
             }
         }
 
@@ -140,7 +144,7 @@ namespace AvaloniaEdit.TextMate
             // only resize the array if the line count has changed, otherwise reuse the existing array
             if (_lineRanges.Length != _lineCount)
             {
-            Array.Resize(ref _lineRanges, _lineCount);
+                Array.Resize(ref _lineRanges, _lineCount);
             }
 
             int currentLineIndex = (e != null) ?

--- a/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
+++ b/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
@@ -137,7 +137,11 @@ namespace AvaloniaEdit.TextMate
 
         private void RecomputeAllLineRanges(DocumentChangeEventArgs e)
         {
+            // only resize the array if the line count has changed, otherwise reuse the existing array
+            if (_lineRanges.Length != _lineCount)
+            {
             Array.Resize(ref _lineRanges, _lineCount);
+            }
 
             int currentLineIndex = (e != null) ?
                 _document.GetLineByOffset(e.Offset).LineNumber - 1 : 0;

--- a/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
+++ b/src/AvaloniaEdit.TextMate/DocumentSnapshot.cs
@@ -19,6 +19,7 @@ namespace AvaloniaEdit.TextMate
 
         public DocumentSnapshot(TextDocument document)
         {
+            ArgumentNullException.ThrowIfNull(document);
             _document = document;
             _lineRanges = new LineRange[document.LineCount];
 
@@ -27,10 +28,15 @@ namespace AvaloniaEdit.TextMate
 
         public void RemoveLines(int startLine, int endLine)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(startLine);
+            ArgumentOutOfRangeException.ThrowIfLessThan(endLine, startLine);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(endLine, _lineCount);
+
                 int removeCount = endLine - startLine + 1;
                 int shiftCount = _lineCount - (endLine + 1);
+
                 if (shiftCount > 0)
                 {
                     Array.Copy(_lineRanges, endLine + 1, _lineRanges, startLine, shiftCount);
@@ -43,8 +49,11 @@ namespace AvaloniaEdit.TextMate
 
         public string GetLineText(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 var lineRange = _lineRanges[lineIndex];
                 return _textSource.GetText(lineRange.Offset, lineRange.Length);
             }
@@ -52,8 +61,11 @@ namespace AvaloniaEdit.TextMate
 
         public string GetLineTextIncludingTerminator(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 var lineRange = _lineRanges[lineIndex];
                 return _textSource.GetText(lineRange.Offset, lineRange.TotalLength);
             }
@@ -61,8 +73,11 @@ namespace AvaloniaEdit.TextMate
 
         public ReadOnlyMemory<char> GetLineTextIncludingTerminatorAsMemory(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 var lineRange = _lineRanges[lineIndex];
                 return _textSource.GetTextAsMemory(lineRange.Offset, lineRange.TotalLength);
             }
@@ -70,8 +85,11 @@ namespace AvaloniaEdit.TextMate
 
         public string GetLineTerminator(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 var lineRange = _lineRanges[lineIndex];
                 return _textSource.GetText(lineRange.Offset + lineRange.Length, lineRange.TotalLength - lineRange.Length);
             }
@@ -79,16 +97,22 @@ namespace AvaloniaEdit.TextMate
 
         public int GetLineLength(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 return _lineRanges[lineIndex].Length;
             }
         }
 
         public int GetTotalLineLength(int lineIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
             lock (_lock)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, _lineCount);
+
                 return _lineRanges[lineIndex].TotalLength;
             }
         }
@@ -107,7 +131,7 @@ namespace AvaloniaEdit.TextMate
             {
                 _lineCount = _document.Lines.Count;
 
-                if (e != null && e.OffsetChangeMap != null && _lineRanges != null && _lineCount == _lineRanges.Length)
+                if (e?.OffsetChangeMap != null && _lineRanges != null && _lineCount == _lineRanges.Length)
                 {
                     // it's a single-line change
                     // update the offsets usign the OffsetChangeMap
@@ -141,7 +165,6 @@ namespace AvaloniaEdit.TextMate
 
         private void RecomputeAllLineRanges(DocumentChangeEventArgs e)
         {
-            // only resize the array if the line count has changed, otherwise reuse the existing array
             if (_lineRanges.Length != _lineCount)
             {
                 Array.Resize(ref _lineRanges, _lineCount);

--- a/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
+++ b/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
@@ -1,4 +1,5 @@
-﻿using AvaloniaEdit.Document;
+﻿using System;
+using AvaloniaEdit.Document;
 using AvaloniaEdit.TextMate;
 
 using NUnit.Framework;
@@ -137,6 +138,250 @@ namespace AvaloniaEdit.Tests.TextMate
             documentSnaphot.RemoveLines(3, 3);
 
             Assert.AreEqual(3, documentSnaphot.LineCount);
+        }
+
+        [Test]
+        public void Constructor_ShouldInitializeSnapshotFromDocument()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("alpha\r\nbeta\r\ngamma");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Act
+            int lineCount = snapshot.LineCount;
+            string text = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+            string thirdLine = snapshot.GetLineText(2);
+
+            // Assert
+            Assert.AreEqual(3, lineCount);
+            Assert.AreEqual("alpha\r\nbeta\r\ngamma", text);
+            Assert.AreEqual("alpha", firstLine);
+            Assert.AreEqual("beta", secondLine);
+            Assert.AreEqual("gamma", thirdLine);
+        }
+
+        [Test]
+        public void GetLineMembers_ShouldReturnExpectedValues_ForLineWithTerminator()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("alpha\r\nbeta\r\ngamma");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Act
+            string lineText = snapshot.GetLineText(0);
+            string lineTextIncludingTerminator = snapshot.GetLineTextIncludingTerminator(0);
+            ReadOnlyMemory<char> lineMemoryIncludingTerminator = snapshot.GetLineTextIncludingTerminatorAsMemory(0);
+            string terminator = snapshot.GetLineTerminator(0);
+            int lineLength = snapshot.GetLineLength(0);
+            int totalLineLength = snapshot.GetTotalLineLength(0);
+
+            // Assert
+            Assert.AreEqual("alpha", lineText);
+            Assert.AreEqual("alpha\r\n", lineTextIncludingTerminator);
+            Assert.AreEqual("alpha\r\n", lineMemoryIncludingTerminator.ToString());
+            Assert.AreEqual("\r\n", terminator);
+            Assert.AreEqual(5, lineLength);
+            Assert.AreEqual(7, totalLineLength);
+        }
+
+        [Test]
+        public void GetLineMembers_ShouldReturnExpectedValues_ForLastLineWithoutTerminator()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("alpha\r\nbeta\r\ngamma");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Act
+            string lineText = snapshot.GetLineText(2);
+            string lineTextIncludingTerminator = snapshot.GetLineTextIncludingTerminator(2);
+            ReadOnlyMemory<char> lineMemoryIncludingTerminator = snapshot.GetLineTextIncludingTerminatorAsMemory(2);
+            string terminator = snapshot.GetLineTerminator(2);
+            int lineLength = snapshot.GetLineLength(2);
+            int totalLineLength = snapshot.GetTotalLineLength(2);
+
+            // Assert
+            Assert.AreEqual("gamma", lineText);
+            Assert.AreEqual("gamma", lineTextIncludingTerminator);
+            Assert.AreEqual("gamma", lineMemoryIncludingTerminator.ToString());
+            Assert.AreEqual(string.Empty, terminator);
+            Assert.AreEqual(5, lineLength);
+            Assert.AreEqual(5, totalLineLength);
+        }
+
+        [Test]
+        public void RemoveLines_ShouldRemoveInclusiveRange_AndUpdateLineCount()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("line1\r\nline2\r\nline3\r\nline4");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Act
+            snapshot.RemoveLines(1, 2);
+
+            int lineCount = snapshot.LineCount;
+            string firstRemainingLine = snapshot.GetLineText(0);
+            string secondRemainingLine = snapshot.GetLineText(1);
+
+            // Assert
+            Assert.AreEqual(2, lineCount);
+            Assert.AreEqual("line1", firstRemainingLine);
+            Assert.AreEqual("line4", secondRemainingLine);
+        }
+
+        [Test]
+        public void Update_WithNullChangeArgs_ShouldRecomputeAllLineRanges()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("one\r\ntwo");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            document.Text = "first\r\nsecond\r\nthird";
+
+            // Act
+            snapshot.Update(null);
+
+            int lineCount = snapshot.LineCount;
+            string text = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+            string thirdLine = snapshot.GetLineText(2);
+
+            // Assert
+            Assert.AreEqual(3, lineCount);
+            Assert.AreEqual("first\r\nsecond\r\nthird", text);
+            Assert.AreEqual("first", firstLine);
+            Assert.AreEqual("second", secondLine);
+            Assert.AreEqual("third", thirdLine);
+        }
+
+        [Test]
+        public void Update_WithSingleLineChange_ShouldRecalculateOffsetsUsingOffsetChangeMap()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("ab\r\ncd\r\nef");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            DocumentChangeEventArgs change = CaptureInsertChange(document, 1, "XYZ");
+
+            // Act
+            snapshot.Update(change);
+
+            int lineCount = snapshot.LineCount;
+            string fullText = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+            string thirdLine = snapshot.GetLineText(2);
+            string secondLineWithTerminator = snapshot.GetLineTextIncludingTerminator(1);
+            int firstLineLength = snapshot.GetLineLength(0);
+            int secondLineTotalLength = snapshot.GetTotalLineLength(1);
+
+            // Assert
+            Assert.AreEqual(3, lineCount);
+            Assert.AreEqual("aXYZb\r\ncd\r\nef", fullText);
+            Assert.AreEqual("aXYZb", firstLine);
+            Assert.AreEqual("cd", secondLine);
+            Assert.AreEqual("ef", thirdLine);
+            Assert.AreEqual("cd\r\n", secondLineWithTerminator);
+            Assert.AreEqual(5, firstLineLength);
+            Assert.AreEqual(4, secondLineTotalLength);
+        }
+
+        [Test]
+        public void Update_WithLineCountChange_ShouldRecomputeAllLineRanges()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("ab\r\ncd");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            DocumentChangeEventArgs change = CaptureInsertChange(document, 2, "\r\nxx");
+
+            // Act
+            snapshot.Update(change);
+
+            int lineCount = snapshot.LineCount;
+            string fullText = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+            string thirdLine = snapshot.GetLineText(2);
+
+            // Assert
+            Assert.AreEqual(3, lineCount);
+            Assert.AreEqual("ab\r\nxx\r\ncd", fullText);
+            Assert.AreEqual("ab", firstLine);
+            Assert.AreEqual("xx", secondLine);
+            Assert.AreEqual("cd", thirdLine);
+        }
+
+        [Test]
+        public void Update_AfterRemovingNewline_ShouldRecomputeAllLineRanges_WhenLineCountShrinks()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("ab\r\ncd\r\nef");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            DocumentChangeEventArgs change = CaptureRemoveChange(document, 2, 2);
+
+            // Act
+            snapshot.Update(change);
+
+            int lineCount = snapshot.LineCount;
+            string fullText = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+
+            // Assert
+            Assert.AreEqual(2, lineCount);
+            Assert.AreEqual("abcd\r\nef", fullText);
+            Assert.AreEqual("abcd", firstLine);
+            Assert.AreEqual("ef", secondLine);
+        }
+
+        private static DocumentChangeEventArgs CaptureInsertChange(TextDocument document, int offset, string text)
+        {
+            ChangeRecorder recorder = new ChangeRecorder();
+
+            document.Changed += recorder.OnDocumentChanged;
+            try
+            {
+                document.Insert(offset, text);
+            }
+            finally
+            {
+                document.Changed -= recorder.OnDocumentChanged;
+            }
+
+            Assert.IsNotNull(recorder.LastChange);
+            return recorder.LastChange;
+        }
+
+        private static DocumentChangeEventArgs CaptureRemoveChange(TextDocument document, int offset, int length)
+        {
+            ChangeRecorder recorder = new ChangeRecorder();
+
+            document.Changed += recorder.OnDocumentChanged;
+            try
+            {
+                document.Remove(offset, length);
+            }
+            finally
+            {
+                document.Changed -= recorder.OnDocumentChanged;
+            }
+
+            Assert.IsNotNull(recorder.LastChange);
+            return recorder.LastChange;
+        }
+
+        private sealed class ChangeRecorder
+        {
+            public DocumentChangeEventArgs LastChange { get; private set; }
+
+            public void OnDocumentChanged(object sender, DocumentChangeEventArgs e)
+            {
+                LastChange = e;
+            }
         }
     }
 }

--- a/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
+++ b/test/AvaloniaEdit.Tests/TextMate/DocumentSnapshotTests.cs
@@ -8,8 +8,76 @@ using Assert = NUnit.Framework.Legacy.ClassicAssert;
 namespace AvaloniaEdit.Tests.TextMate
 {
     [TestFixture]
-    internal class DocumentSnapshotTests
+    public class DocumentSnapshotTests
     {
+        #region Constructor tests
+
+        [Test]
+        public void Constructor_Should_Throw_When_Document_Is_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DocumentSnapshot(null));
+        }
+
+        [Test]
+        public void Constructor_Should_Initialize_LineCount_From_Document()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo\ncharlie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(3, snapshot.LineCount);
+        }
+
+        [Test]
+        public void Constructor_Should_Initialize_With_Empty_Document()
+        {
+            TextDocument document = new TextDocument();
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(1, snapshot.LineCount);
+            Assert.AreEqual("", snapshot.GetLineText(0));
+        }
+
+        [Test]
+        public void Constructor_Should_Initialize_With_Single_Line_Document()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "hello";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(1, snapshot.LineCount);
+            Assert.AreEqual("hello", snapshot.GetLineText(0));
+        }
+
+        [Test]
+        public void Constructor_ShouldInitializeSnapshotFromDocument()
+        {
+            // Arrange
+            TextDocument document = new TextDocument("alpha\r\nbeta\r\ngamma");
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Act
+            int lineCount = snapshot.LineCount;
+            string text = snapshot.GetText();
+            string firstLine = snapshot.GetLineText(0);
+            string secondLine = snapshot.GetLineText(1);
+            string thirdLine = snapshot.GetLineText(2);
+
+            // Assert
+            Assert.AreEqual(3, lineCount);
+            Assert.AreEqual("alpha\r\nbeta\r\ngamma", text);
+            Assert.AreEqual("alpha", firstLine);
+            Assert.AreEqual("beta", secondLine);
+            Assert.AreEqual("gamma", thirdLine);
+        }
+
+        #endregion Constructor tests
+
+        #region GetLineText tests
+
         [Test]
         public void DocumentSnaphot_Should_Have_CorrectLineText()
         {
@@ -22,6 +90,43 @@ namespace AvaloniaEdit.Tests.TextMate
             Assert.AreEqual("pussy", documentSnaphot.GetLineText(1));
             Assert.AreEqual("birdie", documentSnaphot.GetLineText(2));
         }
+
+        [Test]
+        public void GetLineText_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineText(-1));
+        }
+
+        [Test]
+        public void GetLineText_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineText(3));
+        }
+
+        [Test]
+        public void GetLineText_Should_Throw_When_LineIndex_Exceeds_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineText(100));
+        }
+
+        #endregion GetLineText tests
+
+        #region GetLineTextIncludingTerminator tests
 
         [Test]
         public void DocumentSnaphot_Should_Have_CorrectLineText_Including_Terminator()
@@ -50,6 +155,71 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
+        public void GetLineTextIncludingTerminator_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminator(-1));
+        }
+
+        [Test]
+        public void GetLineTextIncludingTerminator_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminator(2));
+        }
+
+        #endregion GetLineTextIncludingTerminator tests
+
+        #region GetLineTextIncludingTerminatorAsMemory tests
+
+        [Test]
+        public void GetLineTextIncludingTerminatorAsMemory_Should_Return_Correct_Content()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("puppy\n", snapshot.GetLineTextIncludingTerminatorAsMemory(0).ToString());
+            Assert.AreEqual("pussy\n", snapshot.GetLineTextIncludingTerminatorAsMemory(1).ToString());
+            Assert.AreEqual("birdie", snapshot.GetLineTextIncludingTerminatorAsMemory(2).ToString());
+        }
+
+        [Test]
+        public void GetLineTextIncludingTerminatorAsMemory_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminatorAsMemory(-1));
+        }
+
+        [Test]
+        public void GetLineTextIncludingTerminatorAsMemory_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminatorAsMemory(2));
+        }
+
+        #endregion GetLineTextIncludingTerminatorAsMemory tests
+
+        #region GetLineTerminator tests
+
+        [Test]
         public void DocumentSnaphot_Should_Have_Correct_Line_Terminators()
         {
             TextDocument document = new TextDocument();
@@ -61,6 +231,45 @@ namespace AvaloniaEdit.Tests.TextMate
             Assert.AreEqual("\r\n", documentSnaphot.GetLineTerminator(1));
             Assert.AreEqual("", documentSnaphot.GetLineTerminator(2));
         }
+
+        [Test]
+        public void GetLineTerminator_Should_Return_LF_For_LF_Document()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("\n", snapshot.GetLineTerminator(0));
+            Assert.AreEqual("\n", snapshot.GetLineTerminator(1));
+            Assert.AreEqual("", snapshot.GetLineTerminator(2));
+        }
+
+        [Test]
+        public void GetLineTerminator_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTerminator(-1));
+        }
+
+        [Test]
+        public void GetLineTerminator_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTerminator(2));
+        }
+
+        #endregion GetLineTerminator tests
+
+        #region GetLineLength tests
 
         [Test]
         public void DocumentSnaphot_Should_Have_Correct_Line_Len()
@@ -76,6 +285,32 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
+        public void GetLineLength_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineLength(-1));
+        }
+
+        [Test]
+        public void GetLineLength_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineLength(2));
+        }
+
+        #endregion GetLineLength tests
+
+        #region GetTotalLineLength tests
+
+        [Test]
         public void DocumentSnaphot_Should_Have_Correct_Line_Total_Len()
         {
             TextDocument document = new TextDocument();
@@ -89,7 +324,117 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
-        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_All_Lines()
+        public void GetTotalLineLength_Should_Throw_When_LineIndex_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetTotalLineLength(-1));
+        }
+
+        [Test]
+        public void GetTotalLineLength_Should_Throw_When_LineIndex_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetTotalLineLength(2));
+        }
+
+        #endregion GetTotalLineLength tests
+
+        #region GetText tests
+
+        [Test]
+        public void GetText_Should_Return_Full_Document_Text()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\npussy\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("puppy\npussy\nbirdie", snapshot.GetText());
+        }
+
+        [Test]
+        public void GetText_Should_Return_Empty_String_For_Empty_Document()
+        {
+            TextDocument document = new TextDocument();
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("", snapshot.GetText());
+        }
+
+        #endregion GetText tests
+
+        #region RemoveLines validation tests
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_StartLine_Is_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(-1, 0));
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_EndLine_Is_Less_Than_StartLine()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(2, 1));
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_EndLine_Equals_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(0, 4));
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_EndLine_Exceeds_LineCount()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(0, 100));
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_Both_Parameters_Are_Negative()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "puppy\r\npussy\r\nbirdie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(-2, -1));
+        }
+
+        #endregion RemoveLines validation tests
+
+        #region RemoveLines functional tests
+
+        [Test]
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_After_Remove_All_Lines()
         {
             TextDocument document = new TextDocument();
             document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
@@ -102,7 +447,7 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
-        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_First_Line()
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_After_Remove_First_Line()
         {
             TextDocument document = new TextDocument();
             document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
@@ -115,7 +460,7 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
-        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_Two_First_Lines()
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_After_Remove_Two_First_Lines()
         {
             TextDocument document = new TextDocument();
             document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
@@ -128,7 +473,7 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
-        public void DocumentSnapshot_Should_Have_Correct_Line_Count_Before_Remove_Last_Line()
+        public void DocumentSnapshot_Should_Have_Correct_Line_Count_After_Remove_Last_Line()
         {
             TextDocument document = new TextDocument();
             document.Text = "puppy\r\npussy\r\nbirdie\r\ndoggie";
@@ -141,26 +486,242 @@ namespace AvaloniaEdit.Tests.TextMate
         }
 
         [Test]
-        public void Constructor_ShouldInitializeSnapshotFromDocument()
+        public void RemoveLines_Should_Remove_Middle_Lines_And_Preserve_Surrounding()
         {
-            // Arrange
-            TextDocument document = new TextDocument("alpha\r\nbeta\r\ngamma");
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo\ncharlie\ndelta\necho";
+
             DocumentSnapshot snapshot = new DocumentSnapshot(document);
 
-            // Act
-            int lineCount = snapshot.LineCount;
-            string text = snapshot.GetText();
-            string firstLine = snapshot.GetLineText(0);
-            string secondLine = snapshot.GetLineText(1);
-            string thirdLine = snapshot.GetLineText(2);
+            // Remove bravo and charlie (lines 1-2)
+            snapshot.RemoveLines(1, 2);
 
-            // Assert
-            Assert.AreEqual(3, lineCount);
-            Assert.AreEqual("alpha\r\nbeta\r\ngamma", text);
-            Assert.AreEqual("alpha", firstLine);
-            Assert.AreEqual("beta", secondLine);
-            Assert.AreEqual("gamma", thirdLine);
+            Assert.AreEqual(3, snapshot.LineCount);
         }
+
+        [Test]
+        public void RemoveLines_Should_Remove_Single_Middle_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo\ncharlie\ndelta\necho";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Remove charlie (line 2)
+            snapshot.RemoveLines(2, 2);
+
+            Assert.AreEqual(4, snapshot.LineCount);
+        }
+
+        [Test]
+        public void RemoveLines_Should_Handle_Sequential_Removals()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo\ncharlie\ndelta";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Remove last line first
+            snapshot.RemoveLines(3, 3);
+            Assert.AreEqual(3, snapshot.LineCount);
+
+            // Remove first line
+            snapshot.RemoveLines(0, 0);
+            Assert.AreEqual(2, snapshot.LineCount);
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+            Assert.AreEqual(0, snapshot.LineCount);
+
+            // Any further removal should throw since there are no lines left
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(0, 0));
+        }
+
+        [Test]
+        public void RemoveLines_Should_Throw_When_StartLine_Equals_LineCount_After_Prior_Removal()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo\ncharlie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Remove last line, leaving 2 lines (indices 0-1)
+            snapshot.RemoveLines(2, 2);
+            Assert.AreEqual(2, snapshot.LineCount);
+
+            // startLine=2 is now out of bounds
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.RemoveLines(2, 2));
+        }
+
+        #endregion RemoveLines functional tests
+
+        #region Accessor validation after RemoveLines tests
+
+        [Test]
+        public void GetLineText_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineText(0));
+        }
+
+        [Test]
+        public void GetLineLength_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineLength(0));
+        }
+
+        [Test]
+        public void GetTotalLineLength_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetTotalLineLength(0));
+        }
+
+        [Test]
+        public void GetLineTerminator_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTerminator(0));
+        }
+
+        [Test]
+        public void GetLineTextIncludingTerminator_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminator(0));
+        }
+
+        [Test]
+        public void GetLineTextIncludingTerminatorAsMemory_Should_Throw_After_All_Lines_Removed()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            snapshot.RemoveLines(0, 1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => snapshot.GetLineTextIncludingTerminatorAsMemory(0));
+        }
+
+        #endregion Accessor validation after RemoveLines tests
+
+        #region Edge case tests
+
+        [Test]
+        public void GetLineText_Should_Return_Empty_String_For_Empty_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\n\ncharlie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("", snapshot.GetLineText(1));
+        }
+
+        [Test]
+        public void GetLineTerminator_Should_Return_Empty_For_Last_Line_Without_Terminator()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\nbravo";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual("", snapshot.GetLineTerminator(1));
+        }
+
+        [Test]
+        public void GetLineLength_Should_Return_Zero_For_Empty_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\n\ncharlie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(0, snapshot.GetLineLength(1));
+        }
+
+        [Test]
+        public void GetTotalLineLength_Should_Include_Terminator_For_Empty_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\n\ncharlie";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            // Empty line still has the \n terminator, so TotalLength = 1
+            Assert.AreEqual(1, snapshot.GetTotalLineLength(1));
+        }
+
+        [Test]
+        public void Single_Line_Document_Should_Have_Correct_Line_Properties()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "hello";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(1, snapshot.LineCount);
+            Assert.AreEqual("hello", snapshot.GetLineText(0));
+            Assert.AreEqual("hello", snapshot.GetLineTextIncludingTerminator(0));
+            Assert.AreEqual("", snapshot.GetLineTerminator(0));
+            Assert.AreEqual(5, snapshot.GetLineLength(0));
+            Assert.AreEqual(5, snapshot.GetTotalLineLength(0));
+        }
+
+        [Test]
+        public void Document_With_Trailing_Newline_Should_Have_Empty_Last_Line()
+        {
+            TextDocument document = new TextDocument();
+            document.Text = "alpha\n";
+
+            DocumentSnapshot snapshot = new DocumentSnapshot(document);
+
+            Assert.AreEqual(2, snapshot.LineCount);
+            Assert.AreEqual("alpha", snapshot.GetLineText(0));
+            Assert.AreEqual("", snapshot.GetLineText(1));
+        }
+
+        #endregion Edge case tests
 
         [Test]
         public void GetLineMembers_ShouldReturnExpectedValues_ForLineWithTerminator()


### PR DESCRIPTION
> [!Important]
> Technically speaking, the parameter validation is a _breaking change_ only because the behavior will change by the throwing of `ArgumentNullException` and `ArgumentOutOfRangeException` where necessary - though it is technically now _correct behavior_.

This pull request makes several improvements to the `DocumentSnapshot` class in `src/AvaloniaEdit.TextMate/DocumentSnapshot.cs`, focusing on thread safety, argument validation, and code efficiency. The most important changes are grouped below:

**Thread Safety and Immutability:**

* Changed `_document` and `_lock` fields to `readonly` to ensure they are not modified after construction, improving thread safety.

**Argument Validation and Error Handling:**

* Added comprehensive argument validation using `ArgumentNullException.ThrowIfNull`, `ArgumentOutOfRangeException.ThrowIfNegative`, `ArgumentOutOfRangeException.ThrowIfLessThan`, and `ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual` in constructors and public methods to catch invalid inputs early. [[1]](diffhunk://#diff-1e908797375cccba31e992ccf784b2ff85ae844f990502cfb3ebdbc051320d8aR22) [[2]](diffhunk://#diff-1e908797375cccba31e992ccf784b2ff85ae844f990502cfb3ebdbc051320d8aR31-R115)

**Performance and Code Simplification:**

* Refactored `RemoveLines` to remove the use of `List<T>` and instead use `Array.Copy` and `Array.Resize` for more efficient in-place array manipulation.
* Updated null checks and conditional logic for `Update` to use null-conditional operators for clarity and conciseness.
* Ensured that `RecomputeAllLineRanges` resizes `_lineRanges` to match `_lineCount` before recomputing, preventing potential out-of-bounds errors.

## Benchmark Results

 * Summary *

	BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
	AMD Ryzen 9 7945HX with Radeon Graphics 2.50GHz, 1 CPU, 32 logical and 16 physical cores

	.NET SDK 10.0.201
  [Host] : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v4

| Method                      | LineCount | RemovePosition | Mean         | Error       | StdDev      | Median       | Ratio        | RatioSD | Gen0     | Gen1     | Gen2     | Allocated | Alloc Ratio |
|---------------------------- |---------- |--------------- |-------------:|------------:|------------:|-------------:|-------------:|--------:|---------:|---------:|---------:|----------:|------------:|
| 'Optimized (Array.Copy)'    | 100       | End            |     100.4 ns |     2.02 ns |     5.56 ns |     103.5 ns | 1.44x faster |   0.12x |   0.1429 |   0.0002 |        - |   2.34 KB |  1.53x less |
| 'Original (ToList/ToArray)' | 100       | End            |     143.8 ns |     2.89 ns |     8.10 ns |     142.5 ns |     baseline |         |   0.2179 |   0.0010 |        - |   3.56 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 100       | Middle         |     127.5 ns |     4.36 ns |    12.52 ns |     123.5 ns | 1.33x faster |   0.14x |   0.1428 |   0.0002 |        - |   2.34 KB |  1.53x less |
| 'Original (ToList/ToArray)' | 100       | Middle         |     167.7 ns |     3.38 ns |     8.96 ns |     171.6 ns |     baseline |         |   0.2179 |   0.0010 |        - |   3.56 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 100       | Start          |     123.0 ns |     4.08 ns |    11.78 ns |     120.6 ns | 1.54x faster |   0.17x |   0.1428 |   0.0002 |        - |   2.34 KB |  1.53x less |
| 'Original (ToList/ToArray)' | 100       | Start          |     188.3 ns |     4.53 ns |    13.28 ns |     191.4 ns |     baseline |         |   0.2179 |   0.0010 |        - |   3.56 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 1000      | End            |     706.1 ns |    13.87 ns |    14.84 ns |     701.3 ns | 1.72x faster |   0.08x |   1.4305 |   0.0620 |        - |  23.43 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 1000      | End            |   1,213.2 ns |    24.18 ns |    53.58 ns |   1,195.1 ns |     baseline |         |   2.1553 |   0.0648 |        - |   35.2 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 1000      | Middle         |     859.1 ns |    19.49 ns |    56.23 ns |     861.1 ns | 1.46x faster |   0.11x |   1.4305 |   0.0620 |        - |  23.43 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 1000      | Middle         |   1,250.7 ns |    24.69 ns |    51.54 ns |   1,238.8 ns |     baseline |         |   2.1553 |   0.0648 |        - |   35.2 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 1000      | Start          |     872.7 ns |    16.91 ns |    24.78 ns |     881.2 ns | 1.66x faster |   0.07x |   1.4305 |   0.0620 |        - |  23.43 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 1000      | Start          |   1,451.8 ns |    28.99 ns |    45.98 ns |   1,456.7 ns |     baseline |         |   2.1553 |   0.0648 |        - |   35.2 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 10000     | End            |  59,193.5 ns |   596.35 ns |   528.65 ns |  59,372.2 ns | 2.19x faster |   0.02x |  74.0356 |  74.0356 |  74.0356 | 234.73 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 10000     | End            | 129,602.5 ns | 1,018.86 ns |   903.19 ns | 129,739.6 ns |     baseline |         | 111.0840 | 111.0840 | 111.0840 | 352.15 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 10000     | Middle         |  60,052.7 ns |   785.84 ns |   696.63 ns |  59,850.6 ns | 1.33x faster |   0.04x |  74.0356 |  74.0356 |  74.0356 | 234.73 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 10000     | Middle         |  80,143.8 ns | 1,554.36 ns | 2,021.10 ns |  80,210.1 ns |     baseline |         | 111.0840 | 111.0840 | 111.0840 | 352.15 KB |             |
|                             |           |                |              |             |             |              |              |         |          |          |          |           |             |
| 'Optimized (Array.Copy)'    | 10000     | Start          |  60,116.1 ns | 1,105.65 ns | 1,034.22 ns |  60,173.9 ns | 1.43x faster |   0.08x |  73.9746 |  73.9746 |  73.9746 | 234.73 KB |  1.50x less |
| 'Original (ToList/ToArray)' | 10000     | Start          |  86,210.6 ns | 1,722.31 ns | 4,537.26 ns |  85,859.8 ns |     baseline |         | 111.0840 | 111.0840 | 111.0840 | 352.15 KB |             |

## Test Coverage

<img width="1645" height="561" alt="image" src="https://github.com/user-attachments/assets/5d1feb2d-24f8-4a2f-bf88-4835510f1ea9" />
