### PR TITLE
TextMate: fall back to a full TextView redraw when the visible-line cache is stale

### DIFF
--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -488,6 +488,12 @@ namespace AvaloniaEdit.TextMate
                 firstLineIndexToRedraw = Clamp(firstLineIndexToRedraw, 0, totalLines);
                 lastLineIndexToRedrawLine = Clamp(lastLineIndexToRedrawLine, 0, totalLines);
 
+                if (!areVisualLinesValid || lastLineIndexToRedrawLine < firstLineIndexToRedraw)
+                {
+                    _textView.Redraw();
+                    return;
+                }
+
                 DocumentLine firstLineToRedraw = document.Lines[firstLineIndexToRedraw];
                 DocumentLine lastLineToRedraw = document.Lines[lastLineIndexToRedrawLine];
 

--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -240,6 +240,11 @@ namespace AvaloniaEdit.TextMate
                 if (_model != null)
                 {
                     _model.SetGrammar(grammar);
+
+                    if (grammar != null)
+                    {
+                        _model.InvalidateLine(0);
+                    }
                 }
             }
         }

--- a/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
+++ b/src/AvaloniaEdit.TextMate/TextMateColoringTransformer.cs
@@ -240,11 +240,6 @@ namespace AvaloniaEdit.TextMate
                 if (_model != null)
                 {
                     _model.SetGrammar(grammar);
-
-                    if (grammar != null)
-                    {
-                        _model.InvalidateLine(0);
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

`TextMateColoringTransformer.ModelTokensChanged` clamps its partial redraw range against the cached visible-line indices. When `SetModel` resets those indices to `(-1, -1)` and `_areVisualLinesValid` to `false`, any tokenizer event that arrives before the first layout pass refills the cache produces an inverted redraw range. `_textView.Redraw(offset, length)` is then called with a negative length and paints nothing, so the newly-tokenized lines stay unstyled until the next layout pass eventually triggers a fresh render (typically a scroll or a click).

This PR detects that state — either `areVisualLinesValid` was `false` at capture time, or the clamped range came out inverted — and falls back to a full `_textView.Redraw()` instead of the broken partial one. The fallback is slightly heavier but only fires in the narrow window before the first layout pass; the partial-redraw path still runs in the common case.

## How this was found

We reproduce this in a Unity Version Control diff viewer that hosts AvaloniaEdit.TextMate. Under rapid file switching the cache is stale frequently enough that the natural race produced an observable "missing syntax highlighting on one side of the diff" symptom; instrumentation logs showed ~160 invalid-range redraw events per session before the fix. A deterministic synthesis that suppresses `TextView_VisualLinesChanged`'s cache update on one side reproduces the failure 100% — with this PR's fallback applied, the same synthesis renders both sides correctly highlighted.

## Edit history

An earlier version of this PR also included a defensive `_model.InvalidateLine(0)` after `_model.SetGrammar(grammar)` in `TextMateColoringTransformer.SetGrammar`, intended to work around `TMModel.SetGrammar`'s same-grammar early-return. After looking into TextMateSharp 2.0.4 more carefully, that workaround turned out to be unnecessary: the underlying tokenizer-thread race it was defending against is explicitly fixed by 2.0.4's `TokenizerThread` rewrite (danipen/TextMateSharp PRs [#114](https://github.com/danipen/TextMateSharp/pull/114), [#115](https://github.com/danipen/TextMateSharp/pull/115), [#121](https://github.com/danipen/TextMateSharp/pull/121)). That commit has been reverted in this branch; only the redraw-range fallback remains.

## Notes

- The redraw-range bug is purely local to `AvaloniaEdit.TextMate` and independent of any TextMateSharp version — applies to all consumers regardless of which `TextMateSharp` package they're on.
- No tests added: `TextMateInstallationTests` currently covers disposal semantics, but exercising the redraw clamping deterministically would require a fairly elaborate harness (a real grammar, a tokenizer thread, a controlled layout-pass scheduler). Happy to add unit tests if there's a pattern the maintainers prefer.
- Verified against the current `master` head.
