### PR TITLE
Fix: Stack overflow when text editor is too small

### DIFF
--- a/src/AvaloniaEdit/Editing/Caret.cs
+++ b/src/AvaloniaEdit/Editing/Caret.cs
@@ -462,13 +462,42 @@ namespace AvaloniaEdit.Editing
             BringCaretToView(0);
         }
 
+        private bool _isUpdatingView;
+
         public void BringCaretToView(double border)
         {
+            // Guard against reentry, which can happen when the TextView height is too small.
+            // See https://github.com/AvaloniaUI/AvaloniaEdit/issues/596
+            if (_isUpdatingView)
+                return;
+
             var caretRectangle = CalculateCaretRectangle();
             if (caretRectangle != default)
             {
-                caretRectangle = caretRectangle.Inflate(border);
-                _textView.MakeVisible(caretRectangle);
+                try
+                {
+                    _isUpdatingView = true;
+
+                    if (border > 0)
+                    {
+                        // Add the specified border, but only when the TextView is large enough. We
+                        // don't want the text to scroll out of view.
+                        double horizontal = 0;
+                        double vertical = 0;
+                        if (_textView.Bounds.Width > caretRectangle.Width + 2 * border)
+                            horizontal = border;
+                        if (_textView.Bounds.Height > caretRectangle.Height + 2 * border)
+                            vertical = border;
+
+                        caretRectangle = caretRectangle.Inflate(new Thickness(horizontal, vertical));
+                    }
+
+                    _textView.MakeVisible(caretRectangle);
+                }
+                finally
+                {
+                    _isUpdatingView = false;
+                }
             }
         }
 


### PR DESCRIPTION
Guard against reentry in `Caret.BringIntoView(double border)` to prevent stack overflow when the `TextEditor` is too small.

Fixes #596 

I also noticed that the text position is unstable. It scrolls to the top of the line when I press a key, and it scrolls halfway down when I click the mouse. This happens because text input calls `BringIntoView(0)` and mouse input calls `BringIntoView(5)`. To prevent the text from jumping up and down, I now only add the extra `border` if there is enough space.