### PR TITLE
Fix UI freeze when drag-selecting past the right edge

### DIFF
--- a/src/AvaloniaEdit/Editing/Caret.cs
+++ b/src/AvaloniaEdit/Editing/Caret.cs
@@ -459,7 +459,7 @@ namespace AvaloniaEdit.Editing
         /// </summary>
         public void BringCaretToView()
         {
-            BringCaretToView(0);
+            BringCaretToView(5.0);
         }
 
         public void BringCaretToView(double border)

--- a/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
+++ b/src/AvaloniaEdit/Editing/SelectionMouseHandler.cs
@@ -763,7 +763,7 @@ namespace AvaloniaEdit.Editing
                     TextArea.Caret.Offset = newWord.Offset < _startWord.Offset ? newWord.Offset : Math.Max(newWord.EndOffset, _startWord.EndOffset);
                 }
             }
-            TextArea.Caret.BringCaretToView(5.0);
+            TextArea.Caret.BringCaretToView();
         }
         #endregion
 

--- a/src/AvaloniaEdit/Rendering/TextView.cs
+++ b/src/AvaloniaEdit/Rendering/TextView.cs
@@ -1576,9 +1576,16 @@ namespace AvaloniaEdit.Rendering
             {
                 newScrollOffsetY = rectangle.Bottom - _scrollViewport.Height;
             }
+
             newScrollOffsetX = ValidateVisualOffset(newScrollOffsetX);
             newScrollOffsetY = ValidateVisualOffset(newScrollOffsetY);
             var newScrollOffset = new Vector(newScrollOffsetX, newScrollOffsetY);
+
+            // Clamp scroll offset to valid range.
+            var (maxScrollOffsetX, maxScrollOffsetY) = _scrollExtent - _scrollViewport;
+            var maxScrollOffset = Vector.Max(Vector.Zero, new Vector(maxScrollOffsetX, maxScrollOffsetY));
+            newScrollOffset = Vector.Min(newScrollOffset, maxScrollOffset);
+
             if (!_scrollOffset.IsClose(newScrollOffset))
             {
                 SetScrollOffset(newScrollOffset);
@@ -2108,13 +2115,13 @@ namespace AvaloniaEdit.Rendering
             set
             {
                 value = new Vector(ValidateVisualOffset(value.X), ValidateVisualOffset(value.Y));
-                var isX = !_scrollOffset.X.IsClose(value.X);
-                var isY = !_scrollOffset.Y.IsClose(value.Y);
-                if (isX || isY)
+                var xChanged = !_scrollOffset.X.IsClose(value.X);
+                var yChanged = !_scrollOffset.Y.IsClose(value.Y);
+                if (xChanged || yChanged)
                 {
                     SetScrollOffset(value);
 
-                    if (isX)
+                    if (xChanged)
                     {
                         InvalidateVisual();
                         TextLayer.InvalidateVisual();


### PR DESCRIPTION
Fixes #606

### Problem

The UI will freeze when dragging the selection past the right edge of the text editor. See details in #606.

### Cause

The expected behavior is that the scrolling stops when the end of the scroll bar is reached. However, in this case `Caret.BringIntoView(5.0)` is called, which adds an artificial border around the caret. When this border lies outside of the range of the scroll viewer then `TextView.MakeVisible` sets an invalid, out-of-range scroll offset. This triggers another `ScrollOffsetChanged` event with the invalid scroll offset. This causes an endless loop, the drag-selecting/scrolling never stops.

### Solution

In `TextView.MakeVisible` clamp the scroll offset to the allowed range.

